### PR TITLE
Fix final const inferred type and also trailing commas in collections

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -695,7 +695,6 @@ module.exports = grammar({
             $.additive_expression,
             $.multiplicative_expression,
             $.relational_expression,
-            $.await_expression,
             $.equality_expression,
             $.logical_and_expression,
             $.bitwise_and_expression,
@@ -1043,7 +1042,7 @@ module.exports = grammar({
 
         await_expression: $ => seq(
             'await',
-            $.unary_expression
+            $._unary_expression
         ),
 
         type_test: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -227,9 +227,6 @@ module.exports = grammar({
         [$._top_level_definition, $.getter_signature],
         [$._top_level_definition, $.setter_signature],
         [$._top_level_definition, $.lambda_expression],
-        [$.inferred_type, $._final_builtin],
-        [$.inferred_type, $._const_builtin],
-        [$.declaration, $._static_or_covariant],
         // [$._expression_without_cascade, $._real_expression]
         // [$.constructor_signature, $._formal_parameter_part],
         // [$._unannotated_type, $.type_parameter],
@@ -2162,8 +2159,8 @@ module.exports = grammar({
         // Types
 
         _final_const_var_or_type: $ => choice(
-            seq($._final_builtin, $._type),
-            seq($._const_builtin, $._type),
+            prec.left(seq($._final_builtin, optional($._type))),
+            prec.left(seq($._const_builtin, optional($._type))),
             $.inferred_type,
             $._type
         ),
@@ -2364,11 +2361,7 @@ module.exports = grammar({
 
         inferred_type: $ => prec(
             DART_PREC.BUILTIN,
-            choice(
-                'var',
-                'final',
-                'const'
-            ),
+            'var',
         ),
 
         _method_header: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -230,6 +230,7 @@ module.exports = grammar({
         [$._top_level_definition, $.const_object_expression, $._final_const_var_or_type],
         [$._final_const_var_or_type, $.const_object_expression],
         [$._final_const_var_or_type],
+        [$.type_parameter, $._type_name],
         // [$._expression_without_cascade, $._real_expression]
         // [$.constructor_signature, $._formal_parameter_part],
         // [$._unannotated_type, $.type_parameter],
@@ -588,12 +589,12 @@ module.exports = grammar({
         // ),
 
         list_literal: $ => seq(
-            '[',
+            optional($.type_arguments), '[',
             commaSepTrailingComma($._element),
             ']'
         ),
         set_or_map_literal: $ => seq(
-            '{',
+            optional($.type_arguments), '{',
             commaSepTrailingComma(
                 $._element
             ),

--- a/grammar.js
+++ b/grammar.js
@@ -227,6 +227,9 @@ module.exports = grammar({
         [$._top_level_definition, $.getter_signature],
         [$._top_level_definition, $.setter_signature],
         [$._top_level_definition, $.lambda_expression],
+        [$._top_level_definition, $.const_object_expression, $._final_const_var_or_type],
+        [$._final_const_var_or_type, $.const_object_expression],
+        [$._final_const_var_or_type],
         // [$._expression_without_cascade, $._real_expression]
         // [$.constructor_signature, $._formal_parameter_part],
         // [$._unannotated_type, $.type_parameter],
@@ -2159,8 +2162,8 @@ module.exports = grammar({
         // Types
 
         _final_const_var_or_type: $ => choice(
-            prec.left(seq($._final_builtin, optional($._type))),
-            prec.left(seq($._const_builtin, optional($._type))),
+            seq($._final_builtin, optional($._type)),
+            seq($._const_builtin, optional($._type)),
             $.inferred_type,
             $._type
         ),

--- a/package.json
+++ b/package.json
@@ -41,17 +41,15 @@
   "scripts": {
     "build_init": "tree-sitter generate && node-gyp configure && node-gyp build",
     "build": "tree-sitter generate && node-gyp build",
-    "test": "tree-sitter test && script/parse-examples",
+    "test": "tree-sitter test",
     "build-test": "tree-sitter generate && node-gyp build && tree-sitter test",
     "watch-test": "npm-watch test",
     "watch-grammar": "npm-watch build-test"
   },
-  "tree-sitter": [
-    {
-      "scope": "source.dart",
-      "file-types": [
-        "dart"
-      ]
-    }
-  ]
+  "tree-sitter": [{
+    "scope": "source.dart",
+    "file-types": [
+      "dart"
+    ]
+  }]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1822,6 +1822,18 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "["
         },
@@ -1879,6 +1891,18 @@
     "set_or_map_literal": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
         {
           "type": "STRING",
           "value": "{"
@@ -9383,6 +9407,10 @@
     ],
     [
       "_final_const_var_or_type"
+    ],
+    [
+      "type_parameter",
+      "_type_name"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2067,10 +2067,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "await_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "equality_expression"
         },
         {
@@ -3377,7 +3373,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "unary_expression"
+          "name": "_unary_expression"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7449,54 +7449,46 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_final_builtin"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_type"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          }
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_final_builtin"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_type"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_const_builtin"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_type"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          }
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_const_builtin"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_type"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -9383,6 +9375,18 @@
     [
       "_top_level_definition",
       "lambda_expression"
+    ],
+    [
+      "_top_level_definition",
+      "const_object_expression",
+      "_final_const_var_or_type"
+    ],
+    [
+      "_final_const_var_or_type",
+      "const_object_expression"
+    ],
+    [
+      "_final_const_var_or_type"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7449,30 +7449,54 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_final_builtin"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_type"
-            }
-          ]
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_final_builtin"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_const_builtin"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_type"
-            }
-          ]
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_const_builtin"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
         },
         {
           "type": "SYMBOL",
@@ -7938,21 +7962,8 @@
       "type": "PREC",
       "value": 0,
       "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "var"
-          },
-          {
-            "type": "STRING",
-            "value": "final"
-          },
-          {
-            "type": "STRING",
-            "value": "const"
-          }
-        ]
+        "type": "STRING",
+        "value": "var"
       }
     },
     "_method_header": {
@@ -9372,18 +9383,6 @@
     [
       "_top_level_definition",
       "lambda_expression"
-    ],
-    [
-      "inferred_type",
-      "_final_builtin"
-    ],
-    [
-      "inferred_type",
-      "_const_builtin"
-    ],
-    [
-      "declaration",
-      "_static_or_covariant"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1850,6 +1850,18 @@
                       }
                     ]
                   }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
@@ -1896,6 +1908,18 @@
                       }
                     ]
                   }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
@@ -7914,8 +7938,21 @@
       "type": "PREC",
       "value": 0,
       "content": {
-        "type": "STRING",
-        "value": "var"
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "var"
+          },
+          {
+            "type": "STRING",
+            "value": "final"
+          },
+          {
+            "type": "STRING",
+            "value": "const"
+          }
+        ]
       }
     },
     "_method_header": {
@@ -9335,6 +9372,18 @@
     [
       "_top_level_definition",
       "lambda_expression"
+    ],
+    [
+      "inferred_type",
+      "_final_builtin"
+    ],
+    [
+      "inferred_type",
+      "_const_builtin"
+    ],
+    [
+      "declaration",
+      "_static_or_covariant"
     ]
   ],
   "externals": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6283,6 +6283,10 @@
           "named": true
         },
         {
+          "type": "type_arguments",
+          "named": true
+        },
+        {
           "type": "unary_expression",
           "named": true
         },
@@ -8209,6 +8213,10 @@
         },
         {
           "type": "throw_expression",
+          "named": true
+        },
+        {
+          "type": "type_arguments",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -170,10 +170,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -343,10 +339,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -486,10 +478,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -606,10 +594,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -846,10 +830,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -1046,10 +1026,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -1154,11 +1130,111 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
+          "type": "_literal",
+          "named": true
+        },
+        {
+          "type": "additive_expression",
+          "named": true
+        },
+        {
+          "type": "assignment_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_and_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_or_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_xor_expression",
+          "named": true
+        },
+        {
+          "type": "cascade_section",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "const_object_expression",
+          "named": true
+        },
+        {
+          "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "function_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_null_expression",
+          "named": true
+        },
+        {
+          "type": "logical_and_expression",
+          "named": true
+        },
+        {
+          "type": "logical_or_expression",
+          "named": true
+        },
+        {
+          "type": "multiplicative_expression",
+          "named": true
+        },
+        {
+          "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "relational_expression",
+          "named": true
+        },
+        {
+          "type": "selector",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "super",
+          "named": true
+        },
+        {
+          "type": "this",
+          "named": true
+        },
+        {
+          "type": "throw_expression",
+          "named": true
+        },
+        {
           "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "unconditional_assignable_selector",
           "named": true
         }
       ]
@@ -1213,10 +1289,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -1340,10 +1412,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -1456,10 +1524,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -1620,10 +1684,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -1744,10 +1804,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -2013,10 +2069,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -2143,10 +2195,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -2259,10 +2307,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -2808,10 +2852,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -2968,10 +3008,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -3099,10 +3135,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -3245,10 +3277,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -3387,10 +3415,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -3525,10 +3549,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -3644,10 +3664,6 @@
           },
           {
             "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "await_expression",
             "named": true
           },
           {
@@ -3783,10 +3799,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -3902,10 +3914,6 @@
           },
           {
             "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "await_expression",
             "named": true
           },
           {
@@ -4085,10 +4093,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -4204,10 +4208,6 @@
           },
           {
             "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "await_expression",
             "named": true
           },
           {
@@ -4343,10 +4343,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -4462,10 +4458,6 @@
           },
           {
             "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "await_expression",
             "named": true
           },
           {
@@ -4712,10 +4704,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -4862,10 +4850,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -5108,10 +5092,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -5256,10 +5236,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -5400,10 +5376,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -5519,10 +5491,6 @@
           },
           {
             "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "await_expression",
             "named": true
           },
           {
@@ -5729,10 +5697,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -5878,10 +5842,6 @@
           },
           {
             "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "await_expression",
             "named": true
           },
           {
@@ -6223,10 +6183,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -6373,10 +6329,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -6489,10 +6441,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -6771,10 +6719,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -6896,10 +6840,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -7152,10 +7092,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -7317,10 +7253,6 @@
             "named": true
           },
           {
-            "type": "await_expression",
-            "named": true
-          },
-          {
             "type": "bitwise_and_expression",
             "named": true
           },
@@ -7436,10 +7368,6 @@
           },
           {
             "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "await_expression",
             "named": true
           },
           {
@@ -7575,10 +7503,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -7887,10 +7811,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -8020,10 +7940,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -8196,10 +8112,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -8366,10 +8278,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -8494,10 +8402,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -8610,10 +8514,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -8817,10 +8717,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -8977,10 +8873,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -9101,10 +8993,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -9221,10 +9109,6 @@
         },
         {
           "type": "assignment_expression_without_cascade",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {
@@ -9662,10 +9546,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -9904,10 +9784,6 @@
           "named": true
         },
         {
-          "type": "await_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -10020,10 +9896,6 @@
         },
         {
           "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "await_expression",
           "named": true
         },
         {

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -178,3 +178,18 @@ class Beyonce {
           (formal_parameter (type_identifier) (identifier))
           (formal_parameter (type_identifier) (identifier))))))
         (function_body (block (comment))))))
+
+==================================================
+collection trailing commas
+==================================================
+
+final map = {"hello": "world",};
+final set = {"hello", "world"};
+
+---
+
+(program 
+  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) 
+    (set_or_map_literal (pair (string_literal) (string_literal))))) 
+  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) 
+    (set_or_map_literal (string_literal) (string_literal)))))

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -189,7 +189,7 @@ final set = {"hello", "world"};
 ---
 
 (program 
-  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) 
+  (local_variable_declaration (initialized_variable_definition (identifier) 
     (set_or_map_literal (pair (string_literal) (string_literal))))) 
-  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) 
+  (local_variable_declaration (initialized_variable_definition (identifier) 
     (set_or_map_literal (string_literal) (string_literal)))))

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -194,3 +194,17 @@ final set = {"hello", "world"};
   (local_variable_declaration (initialized_variable_definition (identifier) 
     (set_or_map_literal (string_literal) (string_literal)))))
 
+==================================================
+collection literal type parameters
+==================================================
+
+final dynamic opts = <dynamic, dynamic>{
+  'transports': ['websocket'],
+  'forceNew': true,
+};
+
+---
+
+(program (local_variable_declaration (initialized_variable_definition (type_identifier) (identifier) 
+  (set_or_map_literal (type_arguments (type_identifier) (type_identifier)) (pair (string_literal) 
+    (list_literal (string_literal))) (pair (string_literal) (true))))))

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -193,3 +193,4 @@ final set = {"hello", "world"};
     (set_or_map_literal (pair (string_literal) (string_literal))))) 
   (local_variable_declaration (initialized_variable_definition (identifier) 
     (set_or_map_literal (string_literal) (string_literal)))))
+

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -355,11 +355,15 @@ variable inferred type declaration
 
 var x = 0;
 final y = 1.0;
+final double y1 = 1.0;
 const z = "100";
+const String z1 = "100";
 
 ---
 
 (program 
   (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (decimal_integer_literal))) 
   (local_variable_declaration (initialized_variable_definition (identifier) (decimal_floating_point_literal))) 
-  (local_variable_declaration (initialized_variable_definition (identifier) (string_literal))))
+  (local_variable_declaration (initialized_variable_definition (type_identifier) (identifier) (decimal_floating_point_literal))) 
+  (local_variable_declaration (initialized_variable_definition (identifier) (string_literal))) 
+  (local_variable_declaration (initialized_variable_definition (type_identifier) (identifier) (string_literal))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -361,5 +361,5 @@ const z = "100";
 
 (program 
   (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (decimal_integer_literal))) 
-  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (decimal_floating_point_literal))) 
-  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (string_literal))))
+  (local_variable_declaration (initialized_variable_definition (identifier) (decimal_floating_point_literal))) 
+  (local_variable_declaration (initialized_variable_definition (identifier) (string_literal))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -347,3 +347,19 @@ enum HandSign {
       (enum_constant name: (identifier))
       (enum_constant name: (identifier))
       (enum_constant name: (identifier)))))
+
+
+=================
+variable inferred type declaration
+=================
+
+var x = 0;
+final y = 1.0;
+const z = "100";
+
+---
+
+(program 
+  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (decimal_integer_literal))) 
+  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (decimal_floating_point_literal))) 
+  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (string_literal))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -295,7 +295,7 @@ for (j.init(i); j.check(); j.update()) {
 )
 
 ================================
-Enhanced for statements
+enhanced for statements
 ================================
 
 for (A b in c) {
@@ -312,3 +312,21 @@ for (A b in c) {
     (block
       (expression_statement (identifier) (selector (argument_part (arguments (identifier))))))))
 
+
+================================
+await expressions
+================================
+
+void main() async {
+  final id = await Future.delayed(const Duration(seconds: 100));
+}
+
+---
+
+(program (function_signature (void_type) (identifier) (formal_parameter_list)) 
+  (function_body (block 
+    (local_variable_declaration (initialized_variable_definition (identifier) (unary_expression 
+      (await_expression (identifier) (selector (assignable_selector (unconditional_assignable_selector (identifier)))) 
+        (selector (argument_part (arguments 
+          (const_object_expression (type_identifier) 
+            (arguments (named_argument (label (identifier)) (decimal_integer_literal))))))))))))))


### PR DESCRIPTION
Final and const weren't included in inferred type. I added them, as well as a test for that.
Also, trailing commas weren't allowed in collections. I added that, as well as a test.
Also added in optional type arguments for map, set and list literals.
Also, await expressions were not working. 