### PR TITLE
Many fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -976,7 +976,7 @@ module.exports = grammar({
             DART_PREC.UNARY_PREFIX,
             choice(
 
-                seq($.prefix_operator, $._expression),
+                seq($.prefix_operator, $._unary_expression),
                 $.await_expression,
                 // prec(DART_PREC.UNARY_POSTFIX, $._postfix_expression),
                 seq(

--- a/grammar.js
+++ b/grammar.js
@@ -91,10 +91,7 @@ const DART_PREC = {
 // TODO: general things to add
 // both string types
 // adjacent strings implicitly concatenated
-// var, final, const
-// list, set and map literals
 //get protocols in classes?
-// positional parameters: cased in [] at end of type params.
 // todo: type test operators: as, is, and is!
 //todo: assignment operators: ??=, and ~/=
 //todo: ?? operator
@@ -103,8 +100,6 @@ const DART_PREC = {
 //todo: rethrow keyword
 //todo: override operator notations
 //todo: add mixins via 'with' keyword
-//todo: add the 'mixin' keyword
-//todo: add collection parameters to list/map literals
 //todo: correct import statements to be strings
 //todo: sync* and async* functions, plus yields
 //
@@ -213,7 +208,7 @@ module.exports = grammar({
             $.enum_declaration,
             $.extension_declaration,
             $.mixin_declaration,
-            // $.type_alias,
+            $.type_alias,
             seq(
                 optional($._external_builtin),
                 $.function_signature,
@@ -1605,6 +1600,17 @@ module.exports = grammar({
             field('name', $.identifier),
             // field('v', optional($.class_body))
         )),
+
+        type_alias: $ => choice(
+            seq($._typedef, 
+                $._type_name, 
+                optional($.type_parameters), 
+                '=', $.function_type, ';'),
+            seq($._typedef, 
+                optional($._type_name), 
+                $._type_name, 
+                $._formal_parameter_part, ';'),
+        ),
 
         class_definition: $ => choice(
             seq(

--- a/grammar.js
+++ b/grammar.js
@@ -146,53 +146,7 @@ module.exports = grammar({
     ],
 
     conflicts: $ => [
-        // [$._metadata, $.annotated_type, $.receiver_parameter],
-        // [$._metadata, $.annotated_type],
-        // [$._variable_declarator_id],
-        // [$._unannotated_type,$._expression],
-        // [$._unannotated_type,$._expression, $.inferred_parameters],
-        // [$._unannotated_type,$.method_reference],
-        // [$._unannotated_type,$.generic_type],
-        // [$._primary, $._unannotated_type],
-        // [$._primary, $.generic_type],
-        // [$._statement, $._primary],
-        // [$.function_signature, $._primary,],
-        // [$._type_name, $._primary,],
-        // [$._simple_formal_parameter, $._primary,],
-        // [$._function_formal_parameter, $._primary,],
-        // [$._type_name, $._function_formal_parameter, $._primary],
-        // [$._type_name, $._simple_formal_parameter],
-        // [$.selector, $.assignable_selector_part],
-        // [$._final_const_var_or_type, $._function_formal_parameter],
-        // [$._final_const_var_or_type, $.function_signature],
-        // [$.variable_declaration, $.initialized_identifier,],
-        // [$.declaration, $._external_and_static],
-        // [$._compound_access, $.scoped_identifier],
-        // [$.explicit_constructor_invocation, $._compound_access],
-        // [$._expression, $.pair],
-        // [$._expression, $.labeled_statement],
         [$.block, $.set_or_map_literal],
-        // [$.relational_expression],
-        // [$.equality_expression],
-        // [$._static_or_covariant, $.method_signature],
-        // [$._expression],
-        // [$.constructor_signature, $.function_signature],
-        // [$.assignable_expression, $.postfix_expression],
-        // [$.initialized_identifier, $._variable_declarator_id],
-        // [$._expression, $._expression_without_cascade],
-        // [$._type_name, $.function_signature],
-        // [$._type_name, $._function_formal_parameter],
-        // [$.postfix_expression, $.assignable_expression],
-        // [$._simple_formal_parameter, $._primary,],
-        // [ $._type_name, $._function_formal_parameter, $._primary,],
-        // [$._type_not_void_not_function, $._function_type_tail],
-        // [$._dot_identifier, $._type_name],
-        // [$._expression],
-        // [$._function_type_tails],
-        // [$._type_not_void_not_function],
-        // [$.cascade_section],
-        // [$.assignable_expression],
-        // [$._argument_list],
         [$._primary, $.function_signature],
         [$._primary, $.function_signature, $._type_name],
         [$._primary, $._type_name],
@@ -224,35 +178,12 @@ module.exports = grammar({
         [$._real_expression, $._below_relational_expression],
         [$._postfix_expression, $.assignable_expression],
         [$._postfix_expression],
-        [$._top_level_definition, $.getter_signature],
-        [$._top_level_definition, $.setter_signature],
         [$._top_level_definition, $.lambda_expression],
         [$._top_level_definition, $.const_object_expression, $._final_const_var_or_type],
         [$._final_const_var_or_type, $.const_object_expression],
         [$._final_const_var_or_type],
         [$.type_parameter, $._type_name],
-        // [$._expression_without_cascade, $._real_expression]
-        // [$.constructor_signature, $._formal_parameter_part],
-        // [$._unannotated_type, $.type_parameter],
-        // [$.lambda_expression, $._expression],
-        //     [$._primary, $.method_invocation],
-        // [$.postfix_expression],
-        // [$._primary, $.assignable_expression,],
-        // [$.declaration, $._external_and_static],//
-        //for testing only!
-        //
-        // [$._primary, $.labeled_statement],
-        // [$.relational_expression],
-        // [$.additive_expression],
-        // [$.cascade_section],
-        // [$._type_not_function, $._type_not_void],
-        // [$._cascade_subsection],
-        // [$._primary, $.generic_type],
-        // [$._primary, $.generic_type, $._function_formal_parameter],
-        // [$._unannotated_type, $._simple_formal_parameter],
-        // [$._final_const_var_or_type, $._function_formal_parameter],
-        // [$._primary, $._function_formal_parameter],
-        // [$.typed_identifier, $._function_formal_parameter]
+        [$.class_definition],
     ],
 
     word: $ => $.identifier,
@@ -264,8 +195,9 @@ module.exports = grammar({
             optional($.script_tag),
             optional($.library_name),
             repeat($.import_or_export),
-            // repeat($.part_directive)
-            repeat($._top_level_definition),
+            repeat($.part_directive),
+            repeat($.part_of_directive),
+            prec.dynamic(20, repeat(prec.dynamic(20, seq(optional($._metadata), $._top_level_definition)))),
             //for testing:
             repeat($._statement)
         ),
@@ -274,65 +206,65 @@ module.exports = grammar({
 
         // _library_definition: $ => ,
 
-        _top_level_definition: $ => prec.left(
-            choice(
-                $.class_definition,
-                $.enum_declaration,
-                // $.type_alias,
-                seq(
-                    optional($._external_builtin),
-                    $.function_signature,
-                    $._semicolon
-                ),
-                seq(
-                    optional($._external_builtin),
-                    $.getter_signature,
-                    $._semicolon
-                ),
-                seq(
-                    optional($._external_builtin),
-                    $.setter_signature,
-                    $._semicolon
-                ),
-                // seq(
-                //     $.lambda_expression,
-                //     $._semicolon
-                // ),
-                //    type get
-                seq(
-                    $.function_signature,
-                    $.function_body
-                ),
-                seq(
-                    optional($._type),
-                    $._get,
-                    $.identifier,
-                    $.function_body
-                ),
-                seq(
-                    optional($._type),
-                    $._set,
-                    $.identifier,
-                    $.formal_parameter_list,
-                    $.function_body
-                ),
-                //    type set
-                //    final or const static final declaration list
-                seq(
-                    choice(
-                        $._final_builtin,
-                        $._const_builtin
-                    ),
-                    optional($._type),
-                    $.static_final_declaration_list,
-                    $._semicolon
-                ),
-                seq(
-                    $.variable_declaration,
-                    $._semicolon
-                )
+        _top_level_definition: $ => prec.dynamic(20, choice(
+            $.class_definition,
+            $.enum_declaration,
+            $.extension_declaration,
+            // $.type_alias,
+            seq(
+                optional($._external_builtin),
+                $.function_signature,
+                $._semicolon
             ),
-        ),
+            seq(
+                optional($._external_builtin),
+                $.getter_signature,
+                $._semicolon
+            ),
+            seq(
+                optional($._external_builtin),
+                $.setter_signature,
+                $._semicolon
+            ),
+            // seq(
+            //     $.lambda_expression,
+            //     $._semicolon
+            // ),
+            //    type get
+            seq(
+                $.function_signature,
+                $.function_body
+            ),
+            seq(
+                optional($._type),
+                $._get,
+                $.identifier,
+                $.function_body
+            ),
+            seq(
+                optional($._type),
+                $._set,
+                $.identifier,
+                $.formal_parameter_list,
+                $.function_body
+            ),
+            //    type set
+            //    final or const static final declaration list
+            seq(
+                choice(
+                    $._final_builtin,
+                    $._const_builtin
+                ),
+                optional($._type),
+                $.static_final_declaration_list,
+                $._semicolon
+            ),
+            seq(
+                $.variable_declaration,
+                $._semicolon
+            )
+        ),),
+        
 
         // Literalss
 
@@ -528,8 +460,7 @@ module.exports = grammar({
             '\'\'\''
         ),
         _raw_string_literal_double_quotes: $ => seq(
-            'r',
-            '"',
+            'r"',
             repeat(choice(
                 $._template_chars_double_single,
                 '\'',
@@ -540,8 +471,7 @@ module.exports = grammar({
             '"'
         ),
         _raw_string_literal_single_quotes: $ => seq(
-            'r',
-            '\'',
+            'r\'',
             repeat(choice(
                 $._template_chars_single_single,
                 '"',
@@ -552,8 +482,7 @@ module.exports = grammar({
             '\''
         ),
         _raw_string_literal_double_quotes_multiple: $ => seq(
-            'r',
-            '"""',
+            'r"""',
             repeat(choice(
                 $._template_chars_double,
                 '\'',
@@ -564,8 +493,7 @@ module.exports = grammar({
             '"""'
         ),
         _raw_string_literal_single_quotes_multiple: $ => seq(
-            'r',
-            '\'\'\'',
+            'r\'\'\'',
             repeat(choice(
                 $._template_chars_single,
                 '"',
@@ -1604,6 +1532,20 @@ module.exports = grammar({
             )
         ),
 
+        part_directive: $ => seq(
+            optional($._metadata),
+            'part',
+            $.uri,
+            $._semicolon
+        ),
+
+        part_of_directive: $ => seq(
+            optional($._metadata),
+            'part of',
+            $.uri,
+            $._semicolon
+        ),
+
         uri: $ => $.string_literal,
 
         configurable_uri: $ => seq(
@@ -1639,9 +1581,6 @@ module.exports = grammar({
         asterisk: $ => '*',
 
         enum_declaration: $ => seq(
-            optional(
-                $._metadata
-            ),
             'enum',
             field('name', $.identifier),
             field('body', $.enum_body)
@@ -1666,7 +1605,6 @@ module.exports = grammar({
 
         class_definition: $ => choice(
             seq(
-                optional($._metadata),
                 optional('abstract'),
                 'class',
                 field('name', $.identifier),
@@ -1681,6 +1619,17 @@ module.exports = grammar({
                 'class',
                 $.mixin_application_class
             )
+        ),
+
+        extension_declaration: $ => choice(
+            seq(
+                'extension',
+                optional(field('name', $.identifier)),
+                'on',
+                field('class', $.identifier),
+                optional(field('type_parameters', $.type_parameters)),
+                field('body', $.extension_body)
+            ),
         ),
 
         _metadata: $ => repeat1($._annotation),
@@ -1768,6 +1717,19 @@ module.exports = grammar({
                 seq(
                     optional($._metadata),
                     $._class_member_definition
+                )
+            ),
+            '}'
+        ),
+        extension_body: $ => seq(
+            '{',
+            repeat(
+                seq(
+                    optional($._metadata),
+                    seq(
+                        $.method_signature,
+                        $.function_body
+                    ),
                 )
             ),
             '}'
@@ -2219,7 +2181,7 @@ module.exports = grammar({
 
         parameter_type_list: $ => seq(
             '(',
-            choice(
+            optional(choice(
                 commaSep1($.normal_parameter_type),
                 seq(
                     commaSep1($.normal_parameter_type),
@@ -2227,7 +2189,7 @@ module.exports = grammar({
                     $.optional_parameter_types,
                 ),
                 $.optional_parameter_types
-            ),
+            ),),
             ')'
         ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -379,7 +379,7 @@ module.exports = grammar({
         )),
 
         decimal_floating_point_literal: $ => token(choice(
-            seq(DIGITS, '.', optional(DIGITS), optional(seq((/[eE]/), optional(choice('-', '+')), DIGITS)), optional(/[fFdD]/)),
+            seq(DIGITS, '.', DIGITS, optional(seq((/[eE]/), optional(choice('-', '+')), DIGITS)), optional(/[fFdD]/)),
             seq('.', DIGITS, optional(seq((/[eE]/), optional(choice('-', '+')), DIGITS)), optional(/[fFdD]/)),
             seq(DIGITS, /[eEpP]/, optional(choice('-', '+')), DIGITS, optional(/[fFdD]/)),
             seq(DIGITS, optional(seq((/[eE]/), optional(choice('-', '+')), DIGITS)), (/[fFdD]/))

--- a/grammar.js
+++ b/grammar.js
@@ -323,8 +323,9 @@ module.exports = grammar({
                         $._final_builtin,
                         $._const_builtin
                     ),
-                    $._type,
-                    $.static_final_declaration_list
+                    optional($._type),
+                    $.static_final_declaration_list,
+                    $._semicolon
                 ),
                 seq(
                     $.variable_declaration,
@@ -975,7 +976,7 @@ module.exports = grammar({
             DART_PREC.UNARY_PREFIX,
             choice(
 
-                seq($.prefix_operator, $.unary_expression),
+                seq($.prefix_operator, $._expression),
                 $.await_expression,
                 // prec(DART_PREC.UNARY_POSTFIX, $._postfix_expression),
                 seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -642,40 +642,32 @@
                 "value": "."
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "[0-9]+"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "_+"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[0-9]+"
-                              }
-                            ]
+                "type": "TOKEN",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[0-9]+"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "PATTERN",
+                            "value": "_+"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[0-9]+"
                           }
-                        }
-                      ]
+                        ]
+                      }
                     }
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
+                  ]
+                }
               },
               {
                 "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -233,12 +233,24 @@
                 ]
               },
               {
-                "type": "SYMBOL",
-                "name": "_type"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
                 "name": "static_final_declaration_list"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_semicolon"
               }
             ]
           },
@@ -3192,7 +3204,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "unary_expression"
+                "name": "_expression"
               }
             ]
           },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -40,7 +40,46 @@
           "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
-            "name": "_top_level_definition"
+            "name": "part_directive"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "part_of_directive"
+          }
+        },
+        {
+          "type": "PREC_DYNAMIC",
+          "value": 20,
+          "content": {
+            "type": "REPEAT",
+            "content": {
+              "type": "PREC_DYNAMIC",
+              "value": 20,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_metadata"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_top_level_definition"
+                  }
+                ]
+              }
+            }
           }
         },
         {
@@ -53,8 +92,8 @@
       ]
     },
     "_top_level_definition": {
-      "type": "PREC_LEFT",
-      "value": 0,
+      "type": "PREC_DYNAMIC",
+      "value": 20,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -65,6 +104,10 @@
           {
             "type": "SYMBOL",
             "name": "enum_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "extension_declaration"
           },
           {
             "type": "SEQ",
@@ -1630,11 +1673,7 @@
       "members": [
         {
           "type": "STRING",
-          "value": "r"
-        },
-        {
-          "type": "STRING",
-          "value": "\""
+          "value": "r\""
         },
         {
           "type": "REPEAT",
@@ -1675,11 +1714,7 @@
       "members": [
         {
           "type": "STRING",
-          "value": "r"
-        },
-        {
-          "type": "STRING",
-          "value": "'"
+          "value": "r'"
         },
         {
           "type": "REPEAT",
@@ -1720,11 +1755,7 @@
       "members": [
         {
           "type": "STRING",
-          "value": "r"
-        },
-        {
-          "type": "STRING",
-          "value": "\"\"\""
+          "value": "r\"\"\""
         },
         {
           "type": "REPEAT",
@@ -1765,11 +1796,7 @@
       "members": [
         {
           "type": "STRING",
-          "value": "r"
-        },
-        {
-          "type": "STRING",
-          "value": "'''"
+          "value": "r'''"
         },
         {
           "type": "REPEAT",
@@ -5442,6 +5469,64 @@
         }
       ]
     },
+    "part_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_metadata"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "part"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "uri"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_semicolon"
+        }
+      ]
+    },
+    "part_of_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_metadata"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "part of"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "uri"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_semicolon"
+        }
+      ]
+    },
     "uri": {
       "type": "SYMBOL",
       "name": "string_literal"
@@ -5581,18 +5666,6 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_metadata"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
           "type": "STRING",
           "value": "enum"
         },
@@ -5683,18 +5756,6 @@
         {
           "type": "SEQ",
           "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_metadata"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
             {
               "type": "CHOICE",
               "members": [
@@ -5811,6 +5872,72 @@
             {
               "type": "SYMBOL",
               "name": "mixin_application_class"
+            }
+          ]
+        }
+      ]
+    },
+    "extension_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "extension"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "name",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "on"
+            },
+            {
+              "type": "FIELD",
+              "name": "class",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "type_parameters",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "type_parameters"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "extension_body"
+              }
             }
           ]
         }
@@ -6151,6 +6278,52 @@
               {
                 "type": "SYMBOL",
                 "name": "_class_member_definition"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "extension_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_metadata"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "method_signature"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "function_body"
+                  }
+                ]
               }
             ]
           }
@@ -7666,32 +7839,7 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "normal_parameter_type"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "normal_parameter_type"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
                   "type": "SEQ",
@@ -7719,8 +7867,42 @@
                   ]
                 },
                 {
-                  "type": "STRING",
-                  "value": ","
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "normal_parameter_type"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "normal_parameter_type"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "optional_parameter_types"
+                    }
+                  ]
                 },
                 {
                   "type": "SYMBOL",
@@ -7729,8 +7911,7 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "optional_parameter_types"
+              "type": "BLANK"
             }
           ]
         },
@@ -9390,14 +9571,6 @@
     ],
     [
       "_top_level_definition",
-      "getter_signature"
-    ],
-    [
-      "_top_level_definition",
-      "setter_signature"
-    ],
-    [
-      "_top_level_definition",
       "lambda_expression"
     ],
     [
@@ -9415,6 +9588,9 @@
     [
       "type_parameter",
       "_type_name"
+    ],
+    [
+      "class_definition"
     ]
   ],
   "externals": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -114,6 +114,10 @@
             "name": "mixin_declaration"
           },
           {
+            "type": "SYMBOL",
+            "name": "type_alias"
+          },
+          {
             "type": "SEQ",
             "members": [
               {
@@ -5760,6 +5764,81 @@
             "type": "SYMBOL",
             "name": "identifier"
           }
+        }
+      ]
+    },
+    "type_alias": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_typedef"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_type_name"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_parameters"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function_type"
+            },
+            {
+              "type": "STRING",
+              "value": ";"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_typedef"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_type_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_type_name"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_formal_parameter_part"
+            },
+            {
+              "type": "STRING",
+              "value": ";"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3204,7 +3204,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_expression"
+                "name": "_unary_expression"
               }
             ]
           },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -110,6 +110,10 @@
             "name": "extension_declaration"
           },
           {
+            "type": "SYMBOL",
+            "name": "mixin_declaration"
+          },
+          {
             "type": "SEQ",
             "members": [
               {
@@ -4281,8 +4285,17 @@
       ]
     },
     "assert_statement": {
-      "type": "SYMBOL",
-      "name": "assertion"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "assertion"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
     },
     "assertion": {
       "type": "SEQ",
@@ -5944,10 +5957,14 @@
       ]
     },
     "_metadata": {
-      "type": "REPEAT1",
+      "type": "PREC_RIGHT",
+      "value": 0,
       "content": {
-        "type": "SYMBOL",
-        "name": "_annotation"
+        "type": "REPEAT1",
+        "content": {
+          "type": "SYMBOL",
+          "name": "_annotation"
+        }
       }
     },
     "type_parameters": {
@@ -6142,18 +6159,6 @@
     "mixin_declaration": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_metadata"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
         {
           "type": "SYMBOL",
           "name": "_mixin"
@@ -6558,6 +6563,10 @@
               "name": "constant_constructor_signature"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "redirecting_factory_constructor_signature"
         },
         {
           "type": "SEQ",
@@ -7015,6 +7024,27 @@
               "value": "super"
             },
             {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "qualified"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
               "type": "SYMBOL",
               "name": "arguments"
             }
@@ -7109,7 +7139,7 @@
                 "members": [
                   {
                     "type": "STRING",
-                    "value": ","
+                    "value": "."
                   },
                   {
                     "type": "SYMBOL",
@@ -7159,7 +7189,7 @@
                 "members": [
                   {
                     "type": "STRING",
-                    "value": ","
+                    "value": "."
                   },
                   {
                     "type": "SYMBOL",
@@ -8642,6 +8672,18 @@
                   }
                 ]
               }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
@@ -8680,6 +8722,18 @@
                   }
                 ]
               }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
@@ -9097,8 +9151,16 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_metadata"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_metadata"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -9107,6 +9169,10 @@
         {
           "type": "SYMBOL",
           "name": "dotted_identifier_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_semicolon"
         }
       ]
     },
@@ -9397,7 +9463,7 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "[a-zA-Z_]\\w*"
+      "value": "[a-zA-Z_$][\\w$]*"
     },
     "comment": {
       "type": "TOKEN",
@@ -9591,6 +9657,13 @@
     ],
     [
       "class_definition"
+    ],
+    [
+      "_normal_formal_parameter"
+    ],
+    [
+      "library_name",
+      "dotted_identifier_list"
     ]
   ],
   "externals": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2815,20 +2815,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "annotation",
-          "named": true
-        },
-        {
-          "type": "marker_annotation",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -3230,6 +3216,79 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "extension_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "function_body",
+          "named": true
+        },
+        {
+          "type": "marker_annotation",
+          "named": true
+        },
+        {
+          "type": "method_signature",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "extension_declaration",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "extension_body",
+            "named": true
+          }
+        ]
+      },
+      "class": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "type_parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_parameters",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -7476,7 +7535,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "normal_parameter_type",
@@ -7605,6 +7664,52 @@
     }
   },
   {
+    "type": "part_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "marker_annotation",
+          "named": true
+        },
+        {
+          "type": "uri",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "part_of_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "marker_annotation",
+          "named": true
+        },
+        {
+          "type": "uri",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "postfix_expression",
     "named": true,
     "fields": {},
@@ -7682,11 +7787,19 @@
           "named": true
         },
         {
+          "type": "annotation",
+          "named": true
+        },
+        {
           "type": "class_definition",
           "named": true
         },
         {
           "type": "enum_declaration",
+          "named": true
+        },
+        {
+          "type": "extension_declaration",
           "named": true
         },
         {
@@ -7718,7 +7831,19 @@
           "named": true
         },
         {
+          "type": "marker_annotation",
+          "named": true
+        },
+        {
           "type": "parameter_type_list",
+          "named": true
+        },
+        {
+          "type": "part_directive",
+          "named": true
+        },
+        {
+          "type": "part_of_directive",
           "named": true
         },
         {
@@ -10426,6 +10551,10 @@
     "named": false
   },
   {
+    "type": "extension",
+    "named": false
+  },
+  {
     "type": "external",
     "named": false
   },
@@ -10534,7 +10663,23 @@
     "named": false
   },
   {
-    "type": "r",
+    "type": "part of",
+    "named": false
+  },
+  {
+    "type": "r\"",
+    "named": false
+  },
+  {
+    "type": "r\"\"\"",
+    "named": false
+  },
+  {
+    "type": "r'",
+    "named": false
+  },
+  {
+    "type": "r'''",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7910,6 +7910,10 @@
           "named": true
         },
         {
+          "type": "type_alias",
+          "named": true
+        },
+        {
           "type": "type_arguments",
           "named": true
         },
@@ -9507,6 +9511,33 @@
         },
         {
           "type": "type_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_alias",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "formal_parameter_list",
+          "named": true
+        },
+        {
+          "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
+          "named": true
+        },
+        {
+          "type": "type_parameters",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9499,7 +9499,19 @@
       "required": true,
       "types": [
         {
+          "type": "_literal",
+          "named": true
+        },
+        {
+          "type": "additive_expression",
+          "named": true
+        },
+        {
           "type": "assignable_expression",
+          "named": true
+        },
+        {
+          "type": "assignment_expression",
           "named": true
         },
         {
@@ -9507,7 +9519,55 @@
           "named": true
         },
         {
+          "type": "bitwise_and_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_or_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_xor_expression",
+          "named": true
+        },
+        {
+          "type": "cascade_section",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "const_object_expression",
+          "named": true
+        },
+        {
+          "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "function_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_null_expression",
+          "named": true
+        },
+        {
           "type": "increment_operator",
+          "named": true
+        },
+        {
+          "type": "logical_and_expression",
+          "named": true
+        },
+        {
+          "type": "logical_or_expression",
           "named": true
         },
         {
@@ -9515,11 +9575,43 @@
           "named": true
         },
         {
+          "type": "multiplicative_expression",
+          "named": true
+        },
+        {
+          "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
           "type": "prefix_operator",
           "named": true
         },
         {
+          "type": "relational_expression",
+          "named": true
+        },
+        {
+          "type": "selector",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
           "type": "super",
+          "named": true
+        },
+        {
+          "type": "this",
+          "named": true
+        },
+        {
+          "type": "throw_expression",
           "named": true
         },
         {
@@ -9528,6 +9620,10 @@
         },
         {
           "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "unconditional_assignable_selector",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2656,6 +2656,10 @@
           "named": true
         },
         {
+          "type": "redirecting_factory_constructor_signature",
+          "named": true
+        },
+        {
           "type": "redirection",
           "named": true
         },
@@ -6046,7 +6050,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
@@ -6059,6 +6063,10 @@
         },
         {
           "type": "field_initializer",
+          "named": true
+        },
+        {
+          "type": "qualified",
           "named": true
         }
       ]
@@ -6710,6 +6718,45 @@
         },
         {
           "type": "mixin_application",
+          "named": true
+        },
+        {
+          "type": "type_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mixin_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "class_body",
+          "named": true
+        },
+        {
+          "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "interfaces",
+          "named": true
+        },
+        {
+          "type": "type_arguments",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
           "named": true
         },
         {
@@ -7835,6 +7882,10 @@
           "named": true
         },
         {
+          "type": "mixin_declaration",
+          "named": true
+        },
+        {
           "type": "parameter_type_list",
           "named": true
         },
@@ -7891,6 +7942,37 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "redirecting_factory_constructor_signature",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "formal_parameter_list",
+          "named": true
+        },
+        {
+          "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "type_arguments",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
           "named": true
         }
       ]

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -70,6 +70,18 @@ get a => r'''Also a string''';
     (identifier) (function_body (string_literal))
   (identifier) (function_body (string_literal)))
 
+
+==================================================
+dart identifier name r (used to conflict/error with raw string literal)
+==================================================
+
+String hello(r) => 'hello';
+
+---
+(program 
+  (function_signature (type_identifier) (identifier) 
+    (formal_parameter_list (formal_parameter (identifier)))) (function_body (string_literal))) 
+
 ==================================================
 dart set literals
 ==================================================
@@ -225,3 +237,38 @@ void main() {
     (await_expression (identifier) (selector (assignable_selector (unconditional_assignable_selector (identifier)))) (selector (argument_part 
     (arguments (decimal_integer_literal) (selector (assignable_selector (unconditional_assignable_selector (identifier)))) 
       (function_expression (formal_parameter_list) (function_expression_body (block))))))))))))
+
+
+==================================================
+part directive
+==================================================
+
+part 'hello.dart';
+
+---
+
+(program (part_directive (uri (string_literal))))
+
+==================================================
+part of directive
+==================================================
+
+part of 'hello.dart';
+
+---
+
+(program (part_of_directive (uri (string_literal))))
+
+==================================================
+extension methods
+==================================================
+
+extension Hello on String {
+  String get hello => 'hello';
+}
+
+---
+
+(program 
+  (extension_declaration (identifier) (identifier) (extension_body 
+    (method_signature (getter_signature (type_identifier) (identifier))) (function_body (string_literal)))))

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -189,9 +189,9 @@ final set = {"hello", "world"};
 ---
 
 (program 
-  (local_variable_declaration (initialized_variable_definition (identifier) 
+  (static_final_declaration_list (static_final_declaration (identifier) 
     (set_or_map_literal (pair (string_literal) (string_literal))))) 
-  (local_variable_declaration (initialized_variable_definition (identifier) 
+  (static_final_declaration_list (static_final_declaration (identifier) 
     (set_or_map_literal (string_literal) (string_literal)))))
 
 ==================================================
@@ -205,6 +205,6 @@ final dynamic opts = <dynamic, dynamic>{
 
 ---
 
-(program (local_variable_declaration (initialized_variable_definition (type_identifier) (identifier) 
+(program (type_identifier) (static_final_declaration_list (static_final_declaration (identifier) 
   (set_or_map_literal (type_arguments (type_identifier) (type_identifier)) (pair (string_literal) 
     (list_literal (string_literal))) (pair (string_literal) (true))))))

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -272,3 +272,46 @@ extension Hello on String {
 (program 
   (extension_declaration (identifier) (identifier) (extension_body 
     (method_signature (getter_signature (type_identifier) (identifier))) (function_body (string_literal)))))
+
+==================================================
+library directive
+==================================================
+
+library myLibrary;
+
+---
+
+(program (library_name (dotted_identifier_list (identifier))))
+
+==================================================
+scoped library directive
+==================================================
+
+library myLibrary.a.cool.library;
+
+---
+
+(program (library_name (dotted_identifier_list (identifier) (identifier) (identifier) (identifier))))
+
+
+==================================================
+redirecting factories
+==================================================
+@freezed
+abstract class MyDataClass implements _$MyDataClass {
+  const factory MyDataClass.initialize({@Default(false) bool debug}) =  _MyDataClassInitialize;
+  factory MyDataClass.debug() => MyDataClass.initialize(debug: true);
+}
+
+---
+
+(program 
+  (marker_annotation (identifier)) 
+  (class_definition (identifier) (interfaces (type_identifier)) 
+    (class_body 
+      (declaration (redirecting_factory_constructor_signature (identifier) (identifier) (formal_parameter_list 
+        (optional_formal_parameters (formal_parameter 
+          (annotation (identifier) (arguments (false))) (type_identifier) (identifier)))) (type_identifier))) 
+      (method_signature (factory_constructor_signature (identifier) (identifier) (formal_parameter_list))) 
+        (function_body (identifier) (selector (assignable_selector (unconditional_assignable_selector (identifier)))) 
+          (selector (argument_part (arguments (named_argument (label (identifier)) (true)))))))))

--- a/test/corpus/dart.txt
+++ b/test/corpus/dart.txt
@@ -208,3 +208,20 @@ final dynamic opts = <dynamic, dynamic>{
 (program (type_identifier) (static_final_declaration_list (static_final_declaration (identifier) 
   (set_or_map_literal (type_arguments (type_identifier) (type_identifier)) (pair (string_literal) 
     (list_literal (string_literal))) (pair (string_literal) (true))))))
+
+==================================================
+extensions on integer literals
+==================================================
+
+void main() {
+  await Future.delayed(10.milliseconds, () {});
+}
+
+---
+
+(program 
+  (function_signature (void_type) (identifier) (formal_parameter_list)) 
+  (function_body (block (expression_statement (unary_expression 
+    (await_expression (identifier) (selector (assignable_selector (unconditional_assignable_selector (identifier)))) (selector (argument_part 
+    (arguments (decimal_integer_literal) (selector (assignable_selector (unconditional_assignable_selector (identifier)))) 
+      (function_expression (formal_parameter_list) (function_expression_body (block))))))))))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -352,8 +352,32 @@ enum HandSign {
 =================
 variable inferred type declaration
 =================
-
 var x = 0;
+
+---
+
+(program 
+   (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (decimal_integer_literal))))
+
+
+=================
+top level annotated declaration
+=================
+
+@annotation
+final y = 0;
+
+---
+
+(program 
+  (marker_annotation (identifier)) 
+  (static_final_declaration_list (static_final_declaration (identifier) (decimal_integer_literal))))
+
+
+=================
+static final top level declaration
+=================
+
 final y = 1.0;
 final double y1 = 1.0;
 const z = "100";
@@ -362,8 +386,7 @@ const String z1 = "100";
 ---
 
 (program 
-  (local_variable_declaration (initialized_variable_definition (inferred_type) (identifier) (decimal_integer_literal))) 
-  (local_variable_declaration (initialized_variable_definition (identifier) (decimal_floating_point_literal))) 
-  (local_variable_declaration (initialized_variable_definition (type_identifier) (identifier) (decimal_floating_point_literal))) 
-  (local_variable_declaration (initialized_variable_definition (identifier) (string_literal))) 
-  (local_variable_declaration (initialized_variable_definition (type_identifier) (identifier) (string_literal))))
+  (static_final_declaration_list (static_final_declaration (identifier) (decimal_floating_point_literal))) 
+  (type_identifier) (static_final_declaration_list (static_final_declaration (identifier) (decimal_floating_point_literal))) 
+  (static_final_declaration_list (static_final_declaration (identifier) (string_literal))) 
+  (type_identifier) (static_final_declaration_list (static_final_declaration (identifier) (string_literal))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -390,3 +390,16 @@ const String z1 = "100";
   (type_identifier) (static_final_declaration_list (static_final_declaration (identifier) (decimal_floating_point_literal))) 
   (static_final_declaration_list (static_final_declaration (identifier) (string_literal))) 
   (type_identifier) (static_final_declaration_list (static_final_declaration (identifier) (string_literal))))
+
+
+=================
+identifier with dollar signs
+=================
+
+final $y$ = 0;
+
+---
+
+(program 
+  (static_final_declaration_list (static_final_declaration (identifier) (decimal_integer_literal))))
+

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -403,3 +403,19 @@ final $y$ = 0;
 (program 
   (static_final_declaration_list (static_final_declaration (identifier) (decimal_integer_literal))))
 
+
+=================
+typedefs
+=================
+
+typedef CreateCallback = void Function(String);
+typedef void EndCallback(String endValue);
+
+---
+
+(program 
+  (type_alias (type_identifier) 
+    (function_type (void_type) 
+      (parameter_type_list (normal_parameter_type (type_identifier))))) 
+  (type_alias (type_identifier) (type_identifier) 
+    (formal_parameter_list (formal_parameter (type_identifier) (identifier)))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -349,3 +349,13 @@ void main() {
     (local_variable_declaration (initialized_variable_definition (identifier) (false))) 
     (if_statement (parenthesized_expression (unary_expression (prefix_operator (negation_operator)) (identifier))) 
       (block (expression_statement (assignment_expression (assignable_expression (identifier)) (identifier))))))))
+
+================================
+assert statement
+================================
+
+assert(x != null);
+
+---
+(program 
+  (assert_statement (assertion (equality_expression (identifier) (equality_operator) (null_literal))))) 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -330,3 +330,22 @@ void main() async {
         (selector (argument_part (arguments 
           (const_object_expression (type_identifier) 
             (arguments (named_argument (label (identifier)) (decimal_integer_literal))))))))))))))
+
+================================
+unary negation expression
+================================
+
+void main() {
+  final remote = false;
+  if (!remote) {
+    server = localUrl;
+  }
+}
+
+---
+
+(program (function_signature (void_type) (identifier) (formal_parameter_list)) 
+  (function_body (block 
+    (local_variable_declaration (initialized_variable_definition (identifier) (false))) 
+    (if_statement (parenthesized_expression (unary_expression (prefix_operator (negation_operator)) (identifier))) 
+      (block (expression_statement (assignment_expression (assignable_expression (identifier)) (identifier))))))))

--- a/test/corpus/more_expressions.txt
+++ b/test/corpus/more_expressions.txt
@@ -167,15 +167,15 @@ class Duck {
 ---
 
 (program
-  (class_definition
-      (annotation
-        (identifier)
-            (arguments (assignment_expression (assignable_expression (identifier)) (string_literal)))
-        )
-      (annotation
-        (identifier)
-            (arguments (assignment_expression (assignable_expression (identifier)) (true)))
-        )
+  (annotation
+    (identifier)
+        (arguments (assignment_expression (assignable_expression (identifier)) (string_literal)))
+    )
+  (annotation
+    (identifier)
+        (arguments (assignment_expression (assignable_expression (identifier)) (true)))
+    )
+    (class_definition
     (identifier)
     (class_body)
   )
@@ -196,8 +196,8 @@ class Quack {
 ---
 
 (program
-  (class_definition
-    (marker_annotation (identifier))
+  (marker_annotation (identifier))
+    (class_definition
     (identifier)
     (class_body
       (marker_annotation (identifier))
@@ -224,11 +224,11 @@ class Quack {
 ---
 
 (program
-  (class_definition
-      (annotation (identifier)
-      (arguments (identifier) (selector (assignable_selector (unconditional_assignable_selector (identifier)))))
-      )
-      (annotation (identifier) (arguments (string_literal)))
+  (annotation (identifier)
+  (arguments (identifier) (selector (assignable_selector (unconditional_assignable_selector (identifier)))))
+  )
+  (annotation (identifier) (arguments (string_literal)))
+    (class_definition
     (identifier)
     (class_body)))
 


### PR DESCRIPTION
* Fixes
  - issue with unary negation that was causing errors
  - floating point specification to allow for extension methods on integers (floating point numbers have to have a number after the decimal point)
  - issue where the identifier 'r' was unavailable because of clashing with raw string literals
  - issue where some things couldn't be annotated
* Adds
  - part declaration
  - part of declaration
  - extension methods
  - library directives
  - $ as a valid part of an identifier
  - function typedefs
* Finishes 
  - adding redirecting constructors and mixins (they were mostly there, just not completed)
  - assertion statement (the semicolon was missing)
* Makes top-level-declarations have a high precedence to make sure statements are only parsed in tests

Added a bunch of tests for most of the above. Also tested it on several thousand lines of dart code on my computer and currently doesn't have any errors in the output. I'll continue testing it out on my personal code and projects and submit pull requests when I find issues.

@UserNobody14 
Ready for review. If you have some personal projects / dart code to test this on it would be great to see if we can find any more errors.
I just run 
```bash
tree-sitter parse /path/to/a/dart/library/* | grep "ERROR"
```
You have to do it for each folder in the library individually as far as I know.