### PR TITLE
Mark the rule '_if_null_expression' explicitly as inline

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -88,6 +88,7 @@ module.exports = grammar({
     inline: $ => [
         $._ambiguous_name,
         $._class_member_definition,
+        $._if_null_expression,
     ],
 
     conflicts: $ => [


### PR DESCRIPTION
This marks the rule `_if_null_expression` explicitly as inline so as to not rely on tree-sitter auto-inlining it. We run into a problem when we unhide (automatically) the rule by removing the leading underscore. This causes the rule to no longer be inlined, resulting in the following conflict:

```
dart: Importing initial 'grammar.json'.
dart: Simplifying 'grammar.json' for ocaml-tree-sitter.
dart: Recovering informational JS grammars from JSON.
dart: Generating definitive 'parser.c'.
Unresolved conflict for symbol sequence:

  real_expression  if_null_expression__repeat1  •  '??'  …

Possible interpretations:

  1:  real_expression  (if_null_expression_  if_null_expression__repeat1)  •  '??'  …
  2:  real_expression  (if_null_expression__repeat1  if_null_expression__repeat1  •  if_null_expression__repeat1)

Possible resolutions:

  1:  Specify a left or right associativity in `if_null_expression_`
  2:  Add a conflict for these rules: `if_null_expression_`
```

The issue is tracked here: https://github.com/tree-sitter/tree-sitter/issues/1683
