### PR TITLE
Use named nodes for things surrounded by braces

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3242,21 +3242,8 @@
           "name": "const_object_expression"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "("
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "parenthesized_expression"
         },
         {
           "type": "SYMBOL",
@@ -3569,6 +3556,23 @@
         }
       ]
     },
+    "index_selector": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
     "cascade_selector": {
       "type": "CHOICE",
       "members": [
@@ -3588,16 +3592,8 @@
               ]
             },
             {
-              "type": "STRING",
-              "value": "["
-            },
-            {
               "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "STRING",
-              "value": "]"
+              "name": "index_selector"
             }
           ]
         },
@@ -3647,16 +3643,8 @@
               ]
             },
             {
-              "type": "STRING",
-              "value": "["
-            },
-            {
               "type": "SYMBOL",
-              "name": "_expression"
-            },
-            {
-              "type": "STRING",
-              "value": "]"
+              "name": "index_selector"
             }
           ]
         },
@@ -4016,6 +4004,15 @@
           "type": "SYMBOL",
           "name": "_assert_builtin"
         },
+        {
+          "type": "SYMBOL",
+          "name": "assertion_arguments"
+        }
+      ]
+    },
+    "assertion_arguments": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "STRING",
           "value": "("
@@ -4509,6 +4506,15 @@
           "value": "catch"
         },
         {
+          "type": "SYMBOL",
+          "name": "catch_parameters"
+        }
+      ]
+    },
+    "catch_parameters": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "STRING",
           "value": "("
         },
@@ -4734,6 +4740,23 @@
           "value": "for"
         },
         {
+          "type": "SYMBOL",
+          "name": "for_loop_parts"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_statement"
+          }
+        }
+      ]
+    },
+    "for_loop_parts": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "STRING",
           "value": "("
         },
@@ -4744,14 +4767,6 @@
         {
           "type": "STRING",
           "value": ")"
-        },
-        {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
-          }
         }
       ]
     },
@@ -4947,16 +4962,8 @@
           "value": "for"
         },
         {
-          "type": "STRING",
-          "value": "("
-        },
-        {
           "type": "SYMBOL",
-          "name": "_for_loop_parts"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
+          "name": "for_loop_parts"
         },
         {
           "type": "FIELD",
@@ -5360,6 +5367,19 @@
           "value": "if"
         },
         {
+          "type": "SYMBOL",
+          "name": "configuration_uri_condition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "uri"
+        }
+      ]
+    },
+    "configuration_uri_condition": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "STRING",
           "value": "("
         },
@@ -5370,10 +5390,6 @@
         {
           "type": "STRING",
           "value": ")"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "uri"
         }
       ]
     },
@@ -10460,7 +10476,8 @@
   ],
   "inline": [
     "_ambiguous_name",
-    "_class_member_definition"
+    "_class_member_definition",
+    "_if_null_expression"
   ],
   "supertypes": [
     "_declaration",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -154,10 +154,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -167,10 +163,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -214,6 +206,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -235,10 +231,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -372,6 +364,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -481,6 +477,21 @@
     "named": true,
     "fields": {},
     "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "assertion_arguments",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "assertion_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
       "multiple": true,
       "required": true,
       "types": [
@@ -550,6 +561,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -612,35 +627,7 @@
           "named": true
         },
         {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
-          "named": true
-        },
-        {
           "type": "conditional_assignable_selector",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
           "named": true
         },
         {
@@ -652,10 +639,6 @@
           "named": true
         },
         {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
           "type": "function_expression",
           "named": true
         },
@@ -664,39 +647,15 @@
           "named": true
         },
         {
-          "type": "if_null_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
           "type": "new_expression",
           "named": true
         },
         {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "relational_expression",
+          "type": "parenthesized_expression",
           "named": true
         },
         {
           "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
           "named": true
         },
         {
@@ -705,22 +664,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
           "named": true
         },
         {
@@ -811,14 +754,6 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -884,6 +819,10 @@
           },
           {
             "type": "new_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
             "named": true
           },
           {
@@ -1015,23 +954,11 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
           {
             "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
             "named": true
           },
           {
@@ -1048,10 +975,6 @@
           },
           {
             "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
             "named": true
           },
           {
@@ -1095,6 +1018,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -1116,10 +1043,6 @@
           },
           {
             "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
             "named": true
           },
           {
@@ -1159,39 +1082,7 @@
           "named": true
         },
         {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
           "type": "const_object_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
           "named": true
         },
         {
@@ -1203,23 +1094,11 @@
           "named": true
         },
         {
-          "type": "if_null_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -1227,15 +1106,7 @@
           "named": true
         },
         {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
           "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
           "named": true
         },
         {
@@ -1244,18 +1115,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
           "named": true
         },
         {
@@ -1317,10 +1176,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -1330,10 +1185,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -1377,6 +1228,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -1398,10 +1253,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -1445,10 +1296,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -1458,10 +1305,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -1505,6 +1348,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -1526,10 +1373,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -1568,10 +1411,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -1581,10 +1420,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -1628,6 +1463,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -1649,10 +1488,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -1725,10 +1560,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "assignment_expression_without_cascade",
           "named": true
         },
@@ -1742,10 +1573,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -1797,6 +1624,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -1818,10 +1649,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -1852,119 +1679,15 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "_literal",
-          "named": true
-        },
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
-          "type": "const_object_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "function_expression",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
         },
         {
-          "type": "if_null_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "new_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
-          "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        },
-        {
-          "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "unconditional_assignable_selector",
+          "type": "index_selector",
           "named": true
         }
       ]
@@ -1972,6 +1695,21 @@
   },
   {
     "type": "catch_clause",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "catch_parameters",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "catch_parameters",
     "named": true,
     "fields": {},
     "children": {
@@ -2134,23 +1872,11 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
           {
             "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
             "named": true
           },
           {
@@ -2167,10 +1893,6 @@
           },
           {
             "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
             "named": true
           },
           {
@@ -2214,6 +1936,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -2235,10 +1961,6 @@
           },
           {
             "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
             "named": true
           },
           {
@@ -2268,23 +1990,11 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
           {
             "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
             "named": true
           },
           {
@@ -2301,10 +2011,6 @@
           },
           {
             "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
             "named": true
           },
           {
@@ -2348,6 +2054,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -2369,10 +2079,6 @@
           },
           {
             "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
             "named": true
           },
           {
@@ -2411,10 +2117,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -2424,10 +2126,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -2471,6 +2169,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -2492,10 +2194,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -2545,9 +2243,24 @@
       "required": true,
       "types": [
         {
-          "type": "uri",
+          "type": "configuration_uri_condition",
           "named": true
         },
+        {
+          "type": "uri",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "configuration_uri_condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
         {
           "type": "uri_test",
           "named": true
@@ -2988,10 +2701,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -3001,10 +2710,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -3052,6 +2757,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -3073,10 +2782,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -3136,51 +2841,11 @@
         "required": false,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
           {
-            "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_and_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_or_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
-            "named": true
-          },
-          {
-            "type": "conditional_expression",
-            "named": true
-          },
-          {
             "type": "const_object_expression",
-            "named": true
-          },
-          {
-            "type": "equality_expression",
             "named": true
           },
           {
@@ -3192,43 +2857,15 @@
             "named": true
           },
           {
-            "type": "if_null_expression",
-            "named": true
-          },
-          {
-            "type": "logical_and_expression",
-            "named": true
-          },
-          {
-            "type": "logical_or_expression",
-            "named": true
-          },
-          {
-            "type": "multiplicative_expression",
-            "named": true
-          },
-          {
             "type": "new_expression",
             "named": true
           },
           {
-            "type": "postfix_expression",
-            "named": true
-          },
-          {
-            "type": "relational_expression",
+            "type": "parenthesized_expression",
             "named": true
           },
           {
             "type": "scoped_identifier",
-            "named": true
-          },
-          {
-            "type": "selector",
-            "named": true
-          },
-          {
-            "type": "shift_expression",
             "named": true
           },
           {
@@ -3237,22 +2874,6 @@
           },
           {
             "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
-            "named": true
-          },
-          {
-            "type": "type_cast_expression",
-            "named": true
-          },
-          {
-            "type": "type_test_expression",
-            "named": true
-          },
-          {
-            "type": "unary_expression",
             "named": true
           },
           {
@@ -3347,6 +2968,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -3538,10 +3163,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -3598,6 +3219,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -3619,10 +3244,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -3667,14 +3288,6 @@
         "multiple": true,
         "required": true,
         "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
           {
             "type": "_literal",
             "named": true
@@ -3756,6 +3369,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -3804,19 +3421,27 @@
             "named": true
           }
         ]
-      },
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "for_loop_parts",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "for_loop_parts",
+    "named": true,
+    "fields": {
       "condition": {
         "multiple": true,
         "required": false,
         "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
           {
             "type": "_literal",
             "named": true
@@ -3886,6 +3511,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -3935,14 +3564,6 @@
         "multiple": true,
         "required": false,
         "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
           {
             "type": "_literal",
             "named": true
@@ -4016,6 +3637,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -4076,14 +3701,6 @@
         "required": false,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -4149,6 +3766,10 @@
           },
           {
             "type": "new_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
             "named": true
           },
           {
@@ -4202,14 +3823,6 @@
         "required": false,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -4275,6 +3888,10 @@
           },
           {
             "type": "new_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
             "named": true
           },
           {
@@ -4384,568 +4001,14 @@
             "named": true
           }
         ]
-      },
-      "condition": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_literal",
-            "named": true
-          },
-          {
-            "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_and_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_or_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
-            "named": true
-          },
-          {
-            "type": "conditional_expression",
-            "named": true
-          },
-          {
-            "type": "const_object_expression",
-            "named": true
-          },
-          {
-            "type": "equality_expression",
-            "named": true
-          },
-          {
-            "type": "function_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "if_null_expression",
-            "named": true
-          },
-          {
-            "type": "logical_and_expression",
-            "named": true
-          },
-          {
-            "type": "logical_or_expression",
-            "named": true
-          },
-          {
-            "type": "multiplicative_expression",
-            "named": true
-          },
-          {
-            "type": "new_expression",
-            "named": true
-          },
-          {
-            "type": "postfix_expression",
-            "named": true
-          },
-          {
-            "type": "relational_expression",
-            "named": true
-          },
-          {
-            "type": "selector",
-            "named": true
-          },
-          {
-            "type": "shift_expression",
-            "named": true
-          },
-          {
-            "type": "super",
-            "named": true
-          },
-          {
-            "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
-            "named": true
-          },
-          {
-            "type": "type_cast_expression",
-            "named": true
-          },
-          {
-            "type": "type_test_expression",
-            "named": true
-          },
-          {
-            "type": "unary_expression",
-            "named": true
-          },
-          {
-            "type": "unconditional_assignable_selector",
-            "named": true
-          }
-        ]
-      },
-      "init": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_literal",
-            "named": true
-          },
-          {
-            "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_and_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_or_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
-            "named": true
-          },
-          {
-            "type": "conditional_expression",
-            "named": true
-          },
-          {
-            "type": "const_object_expression",
-            "named": true
-          },
-          {
-            "type": "equality_expression",
-            "named": true
-          },
-          {
-            "type": "function_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "if_null_expression",
-            "named": true
-          },
-          {
-            "type": "local_variable_declaration",
-            "named": true
-          },
-          {
-            "type": "logical_and_expression",
-            "named": true
-          },
-          {
-            "type": "logical_or_expression",
-            "named": true
-          },
-          {
-            "type": "multiplicative_expression",
-            "named": true
-          },
-          {
-            "type": "new_expression",
-            "named": true
-          },
-          {
-            "type": "postfix_expression",
-            "named": true
-          },
-          {
-            "type": "relational_expression",
-            "named": true
-          },
-          {
-            "type": "selector",
-            "named": true
-          },
-          {
-            "type": "shift_expression",
-            "named": true
-          },
-          {
-            "type": "super",
-            "named": true
-          },
-          {
-            "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
-            "named": true
-          },
-          {
-            "type": "type_cast_expression",
-            "named": true
-          },
-          {
-            "type": "type_test_expression",
-            "named": true
-          },
-          {
-            "type": "unary_expression",
-            "named": true
-          },
-          {
-            "type": "unconditional_assignable_selector",
-            "named": true
-          }
-        ]
-      },
-      "name": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          }
-        ]
-      },
-      "update": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_literal",
-            "named": true
-          },
-          {
-            "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_and_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_or_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
-            "named": true
-          },
-          {
-            "type": "conditional_expression",
-            "named": true
-          },
-          {
-            "type": "const_object_expression",
-            "named": true
-          },
-          {
-            "type": "equality_expression",
-            "named": true
-          },
-          {
-            "type": "function_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "if_null_expression",
-            "named": true
-          },
-          {
-            "type": "logical_and_expression",
-            "named": true
-          },
-          {
-            "type": "logical_or_expression",
-            "named": true
-          },
-          {
-            "type": "multiplicative_expression",
-            "named": true
-          },
-          {
-            "type": "new_expression",
-            "named": true
-          },
-          {
-            "type": "postfix_expression",
-            "named": true
-          },
-          {
-            "type": "relational_expression",
-            "named": true
-          },
-          {
-            "type": "selector",
-            "named": true
-          },
-          {
-            "type": "shift_expression",
-            "named": true
-          },
-          {
-            "type": "super",
-            "named": true
-          },
-          {
-            "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
-            "named": true
-          },
-          {
-            "type": "type_cast_expression",
-            "named": true
-          },
-          {
-            "type": "type_test_expression",
-            "named": true
-          },
-          {
-            "type": "unary_expression",
-            "named": true
-          },
-          {
-            "type": "unconditional_assignable_selector",
-            "named": true
-          }
-        ]
-      },
-      "value": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "_literal",
-            "named": true
-          },
-          {
-            "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_and_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_or_expression",
-            "named": true
-          },
-          {
-            "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
-            "named": true
-          },
-          {
-            "type": "conditional_expression",
-            "named": true
-          },
-          {
-            "type": "const_object_expression",
-            "named": true
-          },
-          {
-            "type": "equality_expression",
-            "named": true
-          },
-          {
-            "type": "function_expression",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "if_null_expression",
-            "named": true
-          },
-          {
-            "type": "logical_and_expression",
-            "named": true
-          },
-          {
-            "type": "logical_or_expression",
-            "named": true
-          },
-          {
-            "type": "multiplicative_expression",
-            "named": true
-          },
-          {
-            "type": "new_expression",
-            "named": true
-          },
-          {
-            "type": "postfix_expression",
-            "named": true
-          },
-          {
-            "type": "relational_expression",
-            "named": true
-          },
-          {
-            "type": "selector",
-            "named": true
-          },
-          {
-            "type": "shift_expression",
-            "named": true
-          },
-          {
-            "type": "super",
-            "named": true
-          },
-          {
-            "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
-            "named": true
-          },
-          {
-            "type": "type_cast_expression",
-            "named": true
-          },
-          {
-            "type": "type_test_expression",
-            "named": true
-          },
-          {
-            "type": "unary_expression",
-            "named": true
-          },
-          {
-            "type": "unconditional_assignable_selector",
-            "named": true
-          }
-        ]
       }
     },
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
         {
-          "type": "annotation",
-          "named": true
-        },
-        {
-          "type": "const_builtin",
-          "named": true
-        },
-        {
-          "type": "final_builtin",
-          "named": true
-        },
-        {
-          "type": "function_type",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "inferred_type",
-          "named": true
-        },
-        {
-          "type": "marker_annotation",
-          "named": true
-        },
-        {
-          "type": "type_arguments",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
-          "named": true
-        },
-        {
-          "type": "void_type",
+          "type": "for_loop_parts",
           "named": true
         }
       ]
@@ -5129,6 +4192,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -5283,6 +4350,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -5484,14 +4555,6 @@
         "required": false,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -5569,6 +4632,10 @@
           },
           {
             "type": "pair",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
             "named": true
           },
           {
@@ -5636,14 +4703,6 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -5724,6 +4783,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -5784,23 +4847,11 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
           {
             "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
             "named": true
           },
           {
@@ -5813,10 +4864,6 @@
           },
           {
             "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
             "named": true
           },
           {
@@ -5860,6 +4907,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -5881,10 +4932,6 @@
           },
           {
             "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
             "named": true
           },
           {
@@ -5910,23 +4957,11 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
           {
             "type": "additive_expression",
-            "named": true
-          },
-          {
-            "type": "assignment_expression",
             "named": true
           },
           {
@@ -5939,10 +4974,6 @@
           },
           {
             "type": "bitwise_xor_expression",
-            "named": true
-          },
-          {
-            "type": "cascade_section",
             "named": true
           },
           {
@@ -5986,6 +5017,10 @@
             "named": true
           },
           {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
             "type": "postfix_expression",
             "named": true
           },
@@ -6007,10 +5042,6 @@
           },
           {
             "type": "this",
-            "named": true
-          },
-          {
-            "type": "throw_expression",
             "named": true
           },
           {
@@ -6116,6 +5147,133 @@
     }
   },
   {
+    "type": "index_selector",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_literal",
+          "named": true
+        },
+        {
+          "type": "additive_expression",
+          "named": true
+        },
+        {
+          "type": "assignment_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_and_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_or_expression",
+          "named": true
+        },
+        {
+          "type": "bitwise_xor_expression",
+          "named": true
+        },
+        {
+          "type": "cascade_section",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "const_object_expression",
+          "named": true
+        },
+        {
+          "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "function_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_null_expression",
+          "named": true
+        },
+        {
+          "type": "logical_and_expression",
+          "named": true
+        },
+        {
+          "type": "logical_or_expression",
+          "named": true
+        },
+        {
+          "type": "multiplicative_expression",
+          "named": true
+        },
+        {
+          "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "relational_expression",
+          "named": true
+        },
+        {
+          "type": "selector",
+          "named": true
+        },
+        {
+          "type": "shift_expression",
+          "named": true
+        },
+        {
+          "type": "super",
+          "named": true
+        },
+        {
+          "type": "this",
+          "named": true
+        },
+        {
+          "type": "throw_expression",
+          "named": true
+        },
+        {
+          "type": "type_cast_expression",
+          "named": true
+        },
+        {
+          "type": "type_test_expression",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "unconditional_assignable_selector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "inferred_type",
     "named": true,
     "fields": {}
@@ -6194,6 +5352,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -6277,14 +5439,6 @@
         "required": false,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -6350,6 +5504,10 @@
           },
           {
             "type": "new_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
             "named": true
           },
           {
@@ -6723,6 +5881,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -6832,10 +5994,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -6845,10 +6003,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -6892,6 +6046,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -6913,10 +6071,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -6955,10 +6109,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -6968,10 +6118,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -7015,6 +6161,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -7036,10 +6186,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -7268,39 +6414,7 @@
           "named": true
         },
         {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
           "type": "const_object_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
           "named": true
         },
         {
@@ -7312,22 +6426,6 @@
           "named": true
         },
         {
-          "type": "if_null_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
           "type": "multiplicative_operator",
           "named": true
         },
@@ -7336,19 +6434,15 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
         {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
           "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
           "named": true
         },
         {
@@ -7357,18 +6451,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
           "named": true
         },
         {
@@ -7465,6 +6547,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -7737,6 +6823,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -7826,14 +6916,6 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -7899,6 +6981,10 @@
           },
           {
             "type": "new_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
             "named": true
           },
           {
@@ -7952,14 +7038,6 @@
         "required": true,
         "types": [
           {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
             "type": "_literal",
             "named": true
           },
@@ -8025,6 +7103,10 @@
           },
           {
             "type": "new_expression",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
             "named": true
           },
           {
@@ -8168,6 +7250,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -8477,6 +7563,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "part_directive",
           "named": true
         },
@@ -8649,10 +7739,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -8662,10 +7748,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -8709,6 +7791,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -8734,10 +7820,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -8838,6 +7920,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -9038,6 +8124,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -9159,10 +8249,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -9172,10 +8258,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -9219,6 +8301,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -9244,10 +8330,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -9348,6 +8430,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -9471,6 +8557,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -9745,6 +8835,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -9913,6 +9007,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -10041,6 +9139,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -10104,10 +9206,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "assignment_expression_without_cascade",
           "named": true
         },
@@ -10121,10 +9219,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -10168,6 +9262,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -10189,10 +9287,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -10430,10 +9524,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -10443,10 +9533,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -10490,6 +9576,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -10511,10 +9601,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -10626,10 +9712,6 @@
           "named": true
         },
         {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
           "type": "bitwise_and_expression",
           "named": true
         },
@@ -10639,10 +9721,6 @@
         },
         {
           "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
           "named": true
         },
         {
@@ -10686,6 +9764,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -10707,10 +9789,6 @@
         },
         {
           "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
           "named": true
         },
         {
@@ -10780,15 +9858,7 @@
           "named": true
         },
         {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
           "type": "assignable_expression",
-          "named": true
-        },
-        {
-          "type": "assignment_expression",
           "named": true
         },
         {
@@ -10796,31 +9866,7 @@
           "named": true
         },
         {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
           "type": "const_object_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
           "named": true
         },
         {
@@ -10832,19 +9878,7 @@
           "named": true
         },
         {
-          "type": "if_null_expression",
-          "named": true
-        },
-        {
           "type": "increment_operator",
-          "named": true
-        },
-        {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
           "named": true
         },
         {
@@ -10852,11 +9886,11 @@
           "named": true
         },
         {
-          "type": "multiplicative_expression",
+          "type": "new_expression",
           "named": true
         },
         {
-          "type": "new_expression",
+          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -10868,15 +9902,7 @@
           "named": true
         },
         {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
           "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
           "named": true
         },
         {
@@ -10888,19 +9914,7 @@
           "named": true
         },
         {
-          "type": "throw_expression",
-          "named": true
-        },
-        {
           "type": "tilde_operator",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
           "named": true
         },
         {
@@ -10919,119 +9933,15 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "_literal",
-          "named": true
-        },
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "assignment_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cascade_section",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
-          "type": "const_object_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "function_expression",
-          "named": true
-        },
         {
           "type": "identifier",
           "named": true
         },
         {
-          "type": "if_null_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "new_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
-          "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        },
-        {
-          "type": "this",
-          "named": true
-        },
-        {
-          "type": "throw_expression",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "unconditional_assignable_selector",
+          "type": "index_selector",
           "named": true
         }
       ]
@@ -11174,6 +10084,10 @@
           "named": true
         },
         {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "postfix_expression",
           "named": true
         },
@@ -11294,6 +10208,10 @@
         },
         {
           "type": "new_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
           "named": true
         },
         {

--- a/test/corpus/big_tests.txt
+++ b/test/corpus/big_tests.txt
@@ -240,7 +240,7 @@ more tests2
     ) 
       (function_body (block (local_variable_declaration 
       (initialized_variable_definition (final_builtin) (type_identifier) (identifier)
-        (identifier) (selector (unconditional_assignable_selector (identifier))))) 
+        (identifier) (selector (unconditional_assignable_selector (index_selector (identifier)))))) 
         (if_statement (parenthesized_expression (equality_expression (identifier) (equality_operator) 
         (null_literal))) (block (return_statement (null_literal)))) 
         (if_statement (parenthesized_expression (logical_and_expression 
@@ -390,7 +390,7 @@ more tests 4
 (function_signature (type_identifier) (identifier) (formal_parameter_list)) 
 (function_body (block (assert_statement 
 (assertion 
-  (logical_and_expression 
+  (assertion_arguments (logical_and_expression 
     (equality_expression (identifier) (equality_operator) (null_literal)) 
     (logical_and_expression 
       (equality_expression (identifier) (equality_operator) (null_literal)) 
@@ -409,7 +409,7 @@ more tests 4
                 )
               )
             )
-          )
+          ))
         )
       ) (return_statement (true)))))
 
@@ -471,14 +471,15 @@ more tests 6
           (block 
             (expression_statement 
               (assignment_expression (assignable_expression (identifier)) 
-              (type_cast_expression (identifier) 
-              (type_cast (as_operator) (type_identifier) (type_arguments (type_identifier)))) 
+              (parenthesized_expression 
+                (type_cast_expression (identifier) 
+                  (type_cast (as_operator) (type_identifier) (type_arguments (type_identifier))))) 
               (selector (unconditional_assignable_selector (identifier))) 
               (selector (argument_part (arguments (argument (this)) (argument (identifier))))))) 
             (expression_statement 
               (identifier) (selector 
               (argument_part (arguments (argument (identifier)) (argument (identifier))))))) 
-        (catch_clause (identifier) (identifier)) 
+        (catch_clause (catch_parameters (identifier) (identifier))) 
           (block 
               (expression_statement (assignment_expression (assignable_expression (identifier)) (identifier) 
                   (selector (unconditional_assignable_selector (identifier))) 
@@ -653,8 +654,8 @@ class Placeholder {
     (class_body (declaration (constructor_signature (identifier) (formal_parameter_list 
     (formal_parameter (constructor_param (this) (identifier))) (formal_parameter (constructor_param (this) (identifier))) 
     (formal_parameter (type_identifier) (type_arguments (type_identifier) (type_identifier)) (identifier)))) (initializers 
-    (initializer_list_entry (assertion (equality_expression (identifier) (equality_operator) (null_literal)))) 
-    (initializer_list_entry (assertion (equality_expression (identifier) (equality_operator) (null_literal)))) 
+    (initializer_list_entry (assertion (assertion_arguments (equality_expression (identifier) (equality_operator) (null_literal))))) 
+    (initializer_list_entry (assertion (assertion_arguments (equality_expression (identifier) (equality_operator) (null_literal))))) 
     (initializer_list_entry (field_initializer (identifier) (identifier) (selector (argument_part (arguments (argument (identifier)) 
     (argument (identifier)) (argument (identifier)) (argument (string_literal))))))) 
     (initializer_list_entry (field_initializer (identifier) 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -203,7 +203,7 @@ max = (a > b) ? a : b;
   (expression_statement (assignment_expression
     left: (assignable_expression (identifier))
     right: (conditional_expression
-      (relational_expression (identifier) (relational_operator) (identifier))
+      (parenthesized_expression (relational_expression (identifier) (relational_operator) (identifier)))
       consequence: (identifier)
       alternative: (identifier)))))
 
@@ -223,7 +223,7 @@ for (j.init(i); j.check(); j.update()) {
 
 (program
   (for_statement
-    init: (local_variable_declaration (initialized_variable_definition
+    (for_loop_parts init: (local_variable_declaration (initialized_variable_definition
         (type_identifier)
         name: (identifier)
         value: (decimal_integer_literal)))
@@ -231,7 +231,7 @@ for (j.init(i); j.check(); j.update()) {
       (identifier)
       (relational_operator)
       (decimal_integer_literal))
-    update: (postfix_expression (assignable_expression (identifier)) (postfix_operator (increment_operator)))
+    update: (postfix_expression (assignable_expression (identifier)) (postfix_operator (increment_operator))))
     body: (block
       (expression_statement
         (identifier)
@@ -258,7 +258,7 @@ for (j.init(i); j.check(); j.update()) {
     )
   )
   (for_statement
-     init: (identifier)
+     (for_loop_parts init: (identifier)
      init: (selector (unconditional_assignable_selector (identifier)))
      init: (selector (argument_part (arguments (argument (identifier)))))
     condition: (identifier)
@@ -266,7 +266,7 @@ for (j.init(i); j.check(); j.update()) {
     condition: (selector (argument_part (arguments)))
     update: (identifier)
     update: (selector (unconditional_assignable_selector (identifier)))
-    update: (selector (argument_part (arguments)))
+    update: (selector (argument_part (arguments))))
     body: (block
       (expression_statement
         (identifier)
@@ -301,9 +301,11 @@ for (A b in c) {
 
 (program
   (for_statement
-    (type_identifier)
-    (identifier)
-    (identifier)
+    (for_loop_parts
+		(type_identifier)
+		(identifier)
+		(identifier)
+	)
     (block
       (expression_statement (identifier) (selector (argument_part (arguments (argument (identifier)))))))))
 
@@ -353,7 +355,7 @@ assert(x != null);
 
 ---
 (program 
-  (assert_statement (assertion (equality_expression (identifier) (equality_operator) (null_literal))))) 
+  (assert_statement (assertion (assertion_arguments (equality_expression (identifier) (equality_operator) (null_literal)))))) 
 
 
 ===========================
@@ -372,7 +374,7 @@ if (data['frame_count'] as int < 5) {
             (relational_expression
                 (type_cast_expression
                     (identifier) (selector
-                                    (unconditional_assignable_selector (string_literal))
+                                    (unconditional_assignable_selector (index_selector (string_literal)))
                                  )
                                  (type_cast (as_operator) (type_identifier))
                 )
@@ -400,12 +402,12 @@ if ((data['frame_count'] as int) < 5) {
     (if_statement
         (parenthesized_expression
             (relational_expression
-                (type_cast_expression
+                (parenthesized_expression (type_cast_expression
                     (identifier) (selector
-                                    (unconditional_assignable_selector (string_literal))
+                                    (unconditional_assignable_selector (index_selector (string_literal)))
                                  )
                                  (type_cast (as_operator) (type_identifier))
-                )
+                ))
                     (relational_operator)
                     (decimal_integer_literal)
             )
@@ -510,7 +512,7 @@ printStream(args['json'] as bool ? '' : 'hi');
                   (argument
                     (conditional_expression
                         (type_cast_expression (identifier)
-                            (selector (unconditional_assignable_selector (string_literal)))
+                            (selector (unconditional_assignable_selector (index_selector (string_literal))))
                             (type_cast (as_operator) (type_identifier))
                         )
                         (string_literal)
@@ -539,10 +541,10 @@ printStream((args['json'] as bool) ? '' : 'hi');
                 (arguments
                   (argument
                     (conditional_expression
-                        (type_cast_expression (identifier)
-                            (selector (unconditional_assignable_selector (string_literal)))
+                        (parenthesized_expression (type_cast_expression (identifier)
+                            (selector (unconditional_assignable_selector (index_selector (string_literal))))
                             (type_cast (as_operator) (type_identifier))
-                        )
+                        ))
                         (string_literal)
                         (string_literal)
                     )
@@ -574,14 +576,14 @@ a as BigB | b as BigB;
     (expression_statement
         (relational_expression
             (type_cast_expression (identifier)
-                (selector (unconditional_assignable_selector (string_literal)))
+                (selector (unconditional_assignable_selector (index_selector (string_literal))))
                 (type_cast (as_operator) (type_identifier)))
             (relational_operator)
             (identifier)))
     (expression_statement
         (relational_expression (identifier) (relational_operator)
             (type_cast_expression (identifier)
-                (selector (unconditional_assignable_selector (string_literal)))
+                (selector (unconditional_assignable_selector (index_selector (string_literal))))
                     (type_cast (as_operator) (type_identifier)))))
     (expression_statement (equality_expression (identifier) (equality_operator) (type_cast_expression (identifier) (type_cast (as_operator) (type_identifier)))))
     (expression_statement (relational_expression (type_cast_expression (identifier) (type_cast (as_operator) (type_identifier))) (relational_operator) (identifier)))
@@ -593,7 +595,7 @@ a as BigB | b as BigB;
         (parenthesized_expression
             (relational_expression
                 (type_cast_expression (identifier)
-                        (selector (unconditional_assignable_selector (string_literal)))
+                        (selector (unconditional_assignable_selector (index_selector (string_literal))))
                         (type_cast (as_operator) (type_identifier)))
                 (relational_operator)
                 (type_cast_expression (identifier) (type_cast (as_operator) (type_identifier))))) (block))
@@ -614,4 +616,4 @@ parameters?["charset"];
 
 (program 
   (expression_statement (identifier) 
-    (selector (unconditional_assignable_selector (string_literal)))))
+    (selector (unconditional_assignable_selector (index_selector (string_literal))))))

--- a/test/corpus/more_expressions.txt
+++ b/test/corpus/more_expressions.txt
@@ -117,7 +117,7 @@ var a;
               )
                (type_identifier)
               (catch_clause
-                (identifier))
+                 (catch_parameters (identifier)))
                  (block
                     (expression_statement
                         (identifier)


### PR DESCRIPTION
This PR creates new named nodes for braces wrapping things. This makes them easily captured.

I'm trying to improve indentation for dart in the helix editor. Computing the indent level is based on tree-sitter and on the nodes surrounding the cursor. In order to correctly capture the nodes which should result in indentation, I made some changes to create such nodes.

For example: the `for_statement` was composed of
```js
optional('await'), 'for', '(', $._for_loop_parts, ')', field('body', $._statement)
```
with no specific node containing just the parenthesis and the `_for_loop_parts`. Thus I created a new named node. The `for_statement` becomes:
```js
optional('await'), 'for', $.for_loop_parts, field('body', $._statement)
```
And the new node `for_loop_parts` is simply:
```js
'(', $._for_loop_parts, ')'
```

I had to adapt the tests to reflect the new nodes.

My work in progress for the queries for indent is [here](https://github.com/seb-bl/helix/blob/master/runtime/queries/dart/indents.scm) (if useful in any way)