### PR TITLE
fix: allow try_statement without catch/finally_clause

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1303,10 +1303,10 @@ module.exports = grammar({
 
         try_statement: $ => seq(
             $._try_head,
-            choice(
+            optional(choice(
                 $.finally_clause,
                 seq(repeat1($._on_part), optional($.finally_clause))
-            )
+            ))
         ),
         _on_part: $ => choice(
             seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4399,32 +4399,40 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "finally_clause"
-            },
-            {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_on_part"
-                  }
+                  "type": "SYMBOL",
+                  "name": "finally_clause"
                 },
                 {
-                  "type": "CHOICE",
+                  "type": "SEQ",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "finally_clause"
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_on_part"
+                      }
                     },
                     {
-                      "type": "BLANK"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "finally_clause"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
                     }
                   ]
                 }
               ]
+            },
+            {
+              "type": "BLANK"
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9366,7 +9366,7 @@
     },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "block",


### PR DESCRIPTION
Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/4632

At the moment, `try_statement` seems to require either a catch or finally clause. This seems to confuse tree-sitter's error recovery when users start with writing only the try block: tree-sitter will parse such incomplete try blocks without a catch/finally clause, like
```
    try {
    }
```
```
    try {
      foo = 1
    }
```
```
    try {
      foo = 1;
    }
```
with widely changing parsing results as the user types. This causes some challenges to editor features like nvim-treesitter's indentation that rely on tree-sitter recognizing `try_statement` or `block`. We might find a way to consider all possible intermediate error states in some way, but I wanted to ask whether it would make more sense to let the parser interpret incomplete `try_statement` in a more meaningful way to support incremental editing (the try block will always be as a child of `ERROR` node until the users finishes with `catch`/`finally`, tough dart seems to require `catch`/`finally` for a valid syntax.

@RobertBrunhage please test! You just need to change the git SHA in nvim-treesitter's lockfile.json to this commit.