### PR TITLE
performance improvement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -149,6 +149,7 @@ module.exports = grammar({
         [$.constant_pattern, $._type_name],
         [$._pattern_field, $.label],
         [$._pattern],
+        [$._legacy_pattern],
         [$.constructor_tearoff, $._identifier_or_new],
         [$._primary, $.constant_pattern, $._simple_formal_parameter],
         [$.record_type_field, $._final_var_or_type],
@@ -1328,6 +1329,13 @@ module.exports = grammar({
             )
         ),
 
+        _legacy_pattern: $ => choice(
+           seq($._legacy_pattern, $.logical_or_operator, $._legacy_pattern),
+           seq($._legacy_pattern, $.logical_and_operator, $._legacy_pattern),
+           seq(choice($.relational_operator, $.equality_operator), $._real_expression),
+           $._unary_pattern,
+        ),
+
         _unary_pattern: $ => choice(
             $.cast_pattern,
             $.null_check_pattern,
@@ -1367,7 +1375,7 @@ module.exports = grammar({
 
         variable_pattern: $ => seq($._final_var_or_type, $.identifier),
 
-        _parenthesized_pattern: $ => seq('(', $._pattern, ')'),
+        _parenthesized_pattern: $ => seq('(', $._legacy_pattern, ')'),
 
         list_pattern: $ => seq(optional($.type_arguments), '[', commaSepTrailingComma($._list_pattern_element), ']'),
 

--- a/grammar.js
+++ b/grammar.js
@@ -149,7 +149,6 @@ module.exports = grammar({
         [$.constant_pattern, $._type_name],
         [$._pattern_field, $.label],
         [$._pattern],
-        [$._legacy_pattern],
         [$.constructor_tearoff, $._identifier_or_new],
         [$._primary, $.constant_pattern, $._simple_formal_parameter],
         [$.record_type_field, $._final_var_or_type],
@@ -1329,13 +1328,6 @@ module.exports = grammar({
             )
         ),
 
-        _legacy_pattern: $ => choice(
-           seq($._legacy_pattern, $.logical_or_operator, $._legacy_pattern),
-           seq($._legacy_pattern, $.logical_and_operator, $._legacy_pattern),
-           seq(choice($.relational_operator, $.equality_operator), $._real_expression),
-           $._unary_pattern,
-        ),
-
         _unary_pattern: $ => choice(
             $.cast_pattern,
             $.null_check_pattern,
@@ -1346,7 +1338,6 @@ module.exports = grammar({
         _primary_pattern: $ => choice(
             $.constant_pattern,
             $.variable_pattern,
-            $._parenthesized_pattern,
             $.list_pattern,
             $.map_pattern,
             $.record_pattern,
@@ -1375,7 +1366,7 @@ module.exports = grammar({
 
         variable_pattern: $ => seq($._final_var_or_type, $.identifier),
 
-        _parenthesized_pattern: $ => seq('(', $._legacy_pattern, ')'),
+        _parenthesized_pattern: $ => seq('(', $._pattern, ')'),
 
         list_pattern: $ => seq(optional($.type_arguments), '[', commaSepTrailingComma($._list_pattern_element), ']'),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4517,6 +4517,71 @@
         ]
       }
     },
+    "_legacy_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_legacy_pattern"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "logical_or_operator"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_legacy_pattern"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_legacy_pattern"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "logical_and_operator"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_legacy_pattern"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "relational_operator"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "equality_operator"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_real_expression"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_unary_pattern"
+        }
+      ]
+    },
     "_unary_pattern": {
       "type": "CHOICE",
       "members": [
@@ -4843,7 +4908,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_pattern"
+          "name": "_legacy_pattern"
         },
         {
           "type": "STRING",
@@ -12323,6 +12388,9 @@
       "_pattern"
     ],
     [
+      "_legacy_pattern"
+    ],
+    [
       "constructor_tearoff",
       "_identifier_or_new"
     ],
@@ -12552,8 +12620,7 @@
   "supertypes": [
     "_declaration",
     "_statement",
-    "_literal",
-    "_element"
+    "_literal"
   ]
 }
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4517,71 +4517,6 @@
         ]
       }
     },
-    "_legacy_pattern": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_legacy_pattern"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "logical_or_operator"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_legacy_pattern"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_legacy_pattern"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "logical_and_operator"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_legacy_pattern"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "relational_operator"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "equality_operator"
-                }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_real_expression"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_unary_pattern"
-        }
-      ]
-    },
     "_unary_pattern": {
       "type": "CHOICE",
       "members": [
@@ -4613,10 +4548,6 @@
         {
           "type": "SYMBOL",
           "name": "variable_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_parenthesized_pattern"
         },
         {
           "type": "SYMBOL",
@@ -4908,7 +4839,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_legacy_pattern"
+          "name": "_pattern"
         },
         {
           "type": "STRING",
@@ -12386,9 +12317,6 @@
     ],
     [
       "_pattern"
-    ],
-    [
-      "_legacy_pattern"
     ],
     [
       "constructor_tearoff",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1822,7 +1822,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "_literal",
@@ -8629,7 +8629,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "_literal",
@@ -8804,7 +8804,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "_literal",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1825,55 +1825,7 @@
       "required": true,
       "types": [
         {
-          "type": "_literal",
-          "named": true
-        },
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cast_pattern",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
-          "type": "const_object_expression",
-          "named": true
-        },
-        {
           "type": "constant_pattern",
-          "named": true
-        },
-        {
-          "type": "constructor_tearoff",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "equality_operator",
-          "named": true
-        },
-        {
-          "type": "function_expression",
           "named": true
         },
         {
@@ -1881,51 +1833,11 @@
           "named": true
         },
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "if_null_expression",
-          "named": true
-        },
-        {
           "type": "list_pattern",
           "named": true
         },
         {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_operator",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_operator",
-          "named": true
-        },
-        {
           "type": "map_pattern",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "new_expression",
-          "named": true
-        },
-        {
-          "type": "null_assert_pattern",
-          "named": true
-        },
-        {
-          "type": "null_check_pattern",
           "named": true
         },
         {
@@ -1937,14 +1849,6 @@
           "named": true
         },
         {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
           "type": "record_pattern",
           "named": true
         },
@@ -1953,55 +1857,11 @@
           "named": true
         },
         {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
-          "type": "relational_operator",
-          "named": true
-        },
-        {
-          "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        },
-        {
-          "type": "switch_expression",
-          "named": true
-        },
-        {
-          "type": "this",
-          "named": true
-        },
-        {
           "type": "type_arguments",
           "named": true
         },
         {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
           "type": "type_identifier",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "unconditional_assignable_selector",
           "named": true
         },
         {
@@ -8628,67 +8488,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "_literal",
-          "named": true
-        },
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cast_pattern",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
-          "type": "const_object_expression",
-          "named": true
-        },
-        {
           "type": "constant_pattern",
-          "named": true
-        },
-        {
-          "type": "constructor_tearoff",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "equality_operator",
-          "named": true
-        },
-        {
-          "type": "function_expression",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "if_null_expression",
           "named": true
         },
         {
@@ -8696,39 +8500,7 @@
           "named": true
         },
         {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_operator",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_operator",
-          "named": true
-        },
-        {
           "type": "map_pattern",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "new_expression",
-          "named": true
-        },
-        {
-          "type": "null_assert_pattern",
-          "named": true
-        },
-        {
-          "type": "null_check_pattern",
           "named": true
         },
         {
@@ -8736,59 +8508,7 @@
           "named": true
         },
         {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
           "type": "record_pattern",
-          "named": true
-        },
-        {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
-          "type": "relational_operator",
-          "named": true
-        },
-        {
-          "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        },
-        {
-          "type": "switch_expression",
-          "named": true
-        },
-        {
-          "type": "this",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "unconditional_assignable_selector",
           "named": true
         },
         {
@@ -8803,67 +8523,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
-          "type": "_literal",
-          "named": true
-        },
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_and_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_or_expression",
-          "named": true
-        },
-        {
-          "type": "bitwise_xor_expression",
-          "named": true
-        },
-        {
-          "type": "cast_pattern",
-          "named": true
-        },
-        {
-          "type": "conditional_expression",
-          "named": true
-        },
-        {
-          "type": "const_object_expression",
-          "named": true
-        },
-        {
           "type": "constant_pattern",
-          "named": true
-        },
-        {
-          "type": "constructor_tearoff",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "equality_operator",
-          "named": true
-        },
-        {
-          "type": "function_expression",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "if_null_expression",
           "named": true
         },
         {
@@ -8871,39 +8535,7 @@
           "named": true
         },
         {
-          "type": "logical_and_expression",
-          "named": true
-        },
-        {
-          "type": "logical_and_operator",
-          "named": true
-        },
-        {
-          "type": "logical_or_expression",
-          "named": true
-        },
-        {
-          "type": "logical_or_operator",
-          "named": true
-        },
-        {
           "type": "map_pattern",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "new_expression",
-          "named": true
-        },
-        {
-          "type": "null_assert_pattern",
-          "named": true
-        },
-        {
-          "type": "null_check_pattern",
           "named": true
         },
         {
@@ -8911,59 +8543,7 @@
           "named": true
         },
         {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
           "type": "record_pattern",
-          "named": true
-        },
-        {
-          "type": "relational_expression",
-          "named": true
-        },
-        {
-          "type": "relational_operator",
-          "named": true
-        },
-        {
-          "type": "selector",
-          "named": true
-        },
-        {
-          "type": "shift_expression",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        },
-        {
-          "type": "switch_expression",
-          "named": true
-        },
-        {
-          "type": "this",
-          "named": true
-        },
-        {
-          "type": "type_cast_expression",
-          "named": true
-        },
-        {
-          "type": "type_test_expression",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "unconditional_assignable_selector",
           "named": true
         },
         {


### PR DESCRIPTION
This PR is just a workaround fix for #46.
all test passed

## Performance
### Test source
```sh
$ cat queries/good.scm
(if_statement)
$ cat queries/bad.scm
(if_statement (block))
$ cat empty.dart # empty file
```

### before changes
```sh
$ time tree-sitter query queries/good.scm empty.dart
tree-sitter query queries/good.scm empty.dart  0.01s user 0.00s system 61% cpu 0.021 total

$ time tree-sitter query queries/bad.scm empty.dart
tree-sitter query queries/bad.scm empty.dart  1.23s user 0.01s system 99% cpu 1.245 total
```

### after changes

```sh
$ time tree-sitter query queries/good.scm empty.dart
tree-sitter query queries/good.scm empty.dart  0.01s user 0.00s system 74% cpu 0.017 total

$ time tree-sitter query queries/bad.scm empty.dart
tree-sitter query queries/bad.scm empty.dart  0.14s user 0.00s system 97% cpu 0.148 total
```
