### PR TITLE
Remove duplicate submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "tree-sitter"]
 	path = tree_sitter/tree-sitter
 	url = git@github.com:tree-sitter/tree-sitter
-[submodule "tree_sitter/tree-sitter"]
-	path = tree_sitter/tree-sitter
-	url = git@github.com:tree-sitter/tree-sitter

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.17"
+tree-sitter = "0.20.9"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Cargo is not happy about duplicate submodules. Having:

```
tree-sitter-dart = { git = "https://github.com/UserNobody14/tree-sitter-dart", rev = "e14bbac8a0fcb6fab1b3becf6ed3fe464123c377" }
```

Result into the error:

```sh
λ cargo fetch

Caused by:
  failed to load source for dependency `tree-sitter-dart`

Caused by:
  Unable to update https://github.com/UserNobody14/tree-sitter-dart?rev=e14bbac8a0fcb6fab1b3becf6ed3fe464123c377

Caused by:
  duplicated submodule path 'tree_sitter/tree-sitter'; class=Submodule (17)
```