### PR TITLE
Fixed issue where type argument brackets were treated as operators

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -28,6 +28,23 @@
 (escape_sequence) @string.escape
 
 [
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+(type_arguments
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+(type_parameters
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+[
  "@"
  "=>"
  ".."
@@ -49,15 +66,6 @@
  (equality_operator)
  (additive_operator)
 ] @operator
-
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-]  @punctuation.bracket
 
 ; Delimiters
 ; --------------------

--- a/test/highlight/types.dart
+++ b/test/highlight/types.dart
@@ -42,3 +42,26 @@ class someClass<T> {
     List<S> list = Collections.emptyList<S>();
   }
 }
+
+class TestClass<A, B> {
+  //           ^ punctuation.bracket
+  //                ^ punctuation.bracket
+
+  List<String> foo() {
+    //^ punctuation.bracket
+    //       ^ punctuation.bracket
+    return <String>[];
+    //     ^ punctuation.bracket
+    //            ^ punctuation.bracket
+  }
+
+  Map test<A, B>() {
+    //    ^ punctuation.bracket
+    //         ^ punctuation.bracket
+    return Map<int, String>.from(<int, String>{});
+    //        ^ punctuation.bracket
+    //                    ^ punctuation.bracket
+    //                           ^ punctuation.bracket
+    //                                       ^ punctuation.bracket
+  }
+}


### PR DESCRIPTION
tree-sitter-dart was treating `<` and `>` as operators when used within type argument lists:

```dart
class Foo<T, U> {}
List<String> bar(){}
void car(Map<String, int> inp);
```

This pr fixes the `highlights.scm` declaration to correctly handle the above brackets as `punctuation.brackets` instead of the `operator` tag