### PR TITLE
Fixed enum constant highlighting

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -92,10 +92,6 @@
   (identifier) @method)
 (setter_signature
   name: (identifier) @method)
-(enum_declaration
-  name: (identifier) @type)
-(enum_constant
-  name: (identifier) @type)
 (type_identifier) @type
 (void_type) @type
 
@@ -105,6 +101,13 @@
  (#match? @type "^[a-zA-Z]"))
 
 (type_identifier) @type
+
+; Enums
+; -------------------
+(enum_declaration
+  name: (identifier) @type)
+(enum_constant
+  name: (identifier) @identifier.constant)
 
 ; Variables
 ; --------------------

--- a/test/highlight/types.dart
+++ b/test/highlight/types.dart
@@ -1,6 +1,7 @@
 enum Material {
   //  ^ type
   DENIM,
+  // <- identifier.constant
   CANVAS
 }
 


### PR DESCRIPTION
Enums constants were incorrectly tagged as `@type`

Since the enum values themselves cannot be used as types, a better selection for these would be `@identifier.constant`

This PR makes this small change