### PR TITLE
Resolved issue caused from bad merge

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -99,10 +99,6 @@
   (identifier) @function)
 (setter_signature
   name: (identifier) @function)
-(enum_declaration
-  name: (identifier) @type)
-(enum_constant
-  name: (identifier) @method)
 (type_identifier) @type
 
 ((scoped_identifier

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -4,8 +4,6 @@
 ; --------------------
 (super) @function
 
-; TODO: add method/call_expression to grammar and
-; distinguish method call from variable access
 (function_expression_body
   (identifier) @function)
 


### PR DESCRIPTION
2 Previous PRs were merged in parallel, causing a bad merge and failed CI

- https://github.com/UserNobody14/tree-sitter-dart/pull/66
- https://github.com/UserNobody14/tree-sitter-dart/pull/65

Enum highlighting is now handled in its own section, and constants are typed as `identifier.constant`

This PR fixes what was added [here](https://github.com/UserNobody14/tree-sitter-dart/pull/66)