### PR TITLE
Support tag query

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "dart"
       ],
       "highlights": "queries/highlights.scm",
+      "tags": ["queries/tags.scm"],
       "injection-regex": "dart"
     }
   ]

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,18 +1,3 @@
-;;;;;;;;;; Reference treesitter python
-;(module (expression_statement (assignment left: (identifier) @name) @definition.constant))
-;
-;(class_definition
-;  name: (identifier) @name) @definition.class
-;
-;(function_definition
-;  name: (identifier) @name) @definition.function
-;
-;(call
-;  function: [
-;      (identifier) @name
-;      (attribute
-;        attribute: (identifier) @name)
-;  ]) @reference.call
 
 (class_definition
   name: (identifier) @name) @definition.class
@@ -59,81 +44,49 @@
 (new_expression
   (type_identifier) @name) @reference.class
 
-;(scoped_identifier
-;  scope: (identifier) @type
-;  name: (identifier) @type)
-;  (#match? @type "^[a-zA-Z]") 
-;@definition.type
-;@property
-
-;(call 
-;  function: [
-;	(identifier) @name
-;	(attribute
-;	  attribute: (identifier) @name)
-;  ]) @reference.call
-
-
-
-;;;;;;;;;;;;;;;;; Reference treesitter elixir
-;; Definitions
-;
-;; * modules and protocols
-;(call
-;  target: (identifier) @ignore
-;  (arguments (alias) @name)
-;  (#match? @ignore "^(defmodule|defprotocol)$")) @definition.module
-;
-;; * functions/macros
-;(call
-;  target: (identifier) @ignore
-;  (arguments
-;    [
-;      ; zero-arity functions with no parentheses
-;      (identifier) @name
-;      ; regular function clause
-;      (call target: (identifier) @name)
-;      ; function clause with a guard clause
-;      (binary_operator
-;        left: (call target: (identifier) @name)
-;        operator: "when")
-;    ])
-;  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
-;
-;; References
-;
-;; ignore calls to kernel/special-forms keywords
-;(call
-;  target: (identifier) @ignore
-;  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defmodule|defprotocol|defimpl|defstruct|defexception|defoverridable|alias|case|cond|else|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
-;
-;; ignore module attributes
-;(unary_operator
-;  operator: "@"
-;  operand: (call
-;    target: (identifier) @ignore))
-;
-;; * function call
-;(call
-;  target: [
-;   ; local
-;   (identifier) @name
-;   ; remote
-;   (dot
-;     right: (identifier) @name)
-;  ]) @reference.call
-;
-;; * pipe into function call
-;(binary_operator
-;  operator: "|>"
-;  right: (identifier) @name) @reference.call
-;
-;; * modules
-;(alias) @name @reference.module
-
 (enum_declaration
   name: (identifier) @name) @definition.enum
 
 (function_signature
   name: (identifier) @name) @definition.function 
+
+(initialized_variable_definition
+  name: (identifier)
+  value: (identifier) @name 
+  value: (selector
+	"!"?
+	(argument_part 
+	  (arguments
+	    (argument)*))?)?) @reference.class
+
+(assignment_expression
+  left: (assignable_expression 
+		  (identifier)
+		  (unconditional_assignable_selector
+			"."
+			(identifier) @name))) @reference.call
+
+(assignment_expression
+  left: (assignable_expression 
+		  (identifier)
+		  (conditional_assignable_selector
+			"?."
+			(identifier) @name))) @reference.call
+
+((identifier) @name
+ (selector
+    "!"?
+    (conditional_assignable_selector
+      "?." (identifier) @name)?
+    (unconditional_assignable_selector
+      "."? (identifier) @name)?
+    (argument_part
+      (arguments
+        (argument)*))?)*
+	(cascade_section
+	  (cascade_selector
+		(identifier)) @name 
+	  (argument_part 
+		(arguments
+		  (argument)*))?)?) @reference.call
 

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,139 @@
+;;;;;;;;;; Reference treesitter python
+;(module (expression_statement (assignment left: (identifier) @name) @definition.constant))
+;
+;(class_definition
+;  name: (identifier) @name) @definition.class
+;
+;(function_definition
+;  name: (identifier) @name) @definition.function
+;
+;(call
+;  function: [
+;      (identifier) @name
+;      (attribute
+;        attribute: (identifier) @name)
+;  ]) @reference.call
+
+(class_definition
+  name: (identifier) @name) @definition.class
+
+(method_signature
+  (function_signature)) @definition.method
+
+(type_alias
+  (type_identifier) @name) @definition.type
+
+(method_signature
+(getter_signature
+  name: (identifier) @name)) @definition.method
+
+(method_signature
+(setter_signature
+  name: (identifier) @name)) @definition.method 
+
+(method_signature
+  (function_signature
+  name: (identifier) @name)) @definition.method
+
+(method_signature
+  (factory_constructor_signature
+    (identifier) @name)) @definition.method
+
+(method_signature
+  (constructor_signature
+  name: (identifier) @name)) @definition.method
+
+(method_signature
+  (operator_signature)) @definition.method
+
+(method_signature) @definition.method
+
+(mixin_declaration
+  (mixin)
+  (identifier) @name) @definition.mixin
+
+(extension_declaration
+  name: (identifier) @name) @definition.extension
+
+
+(new_expression
+  (type_identifier) @name) @reference.class
+
+;(scoped_identifier
+;  scope: (identifier) @type
+;  name: (identifier) @type)
+;  (#match? @type "^[a-zA-Z]") 
+;@definition.type
+;@property
+
+;(call 
+;  function: [
+;	(identifier) @name
+;	(attribute
+;	  attribute: (identifier) @name)
+;  ]) @reference.call
+
+
+
+;;;;;;;;;;;;;;;;; Reference treesitter elixir
+;; Definitions
+;
+;; * modules and protocols
+;(call
+;  target: (identifier) @ignore
+;  (arguments (alias) @name)
+;  (#match? @ignore "^(defmodule|defprotocol)$")) @definition.module
+;
+;; * functions/macros
+;(call
+;  target: (identifier) @ignore
+;  (arguments
+;    [
+;      ; zero-arity functions with no parentheses
+;      (identifier) @name
+;      ; regular function clause
+;      (call target: (identifier) @name)
+;      ; function clause with a guard clause
+;      (binary_operator
+;        left: (call target: (identifier) @name)
+;        operator: "when")
+;    ])
+;  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
+;
+;; References
+;
+;; ignore calls to kernel/special-forms keywords
+;(call
+;  target: (identifier) @ignore
+;  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defmodule|defprotocol|defimpl|defstruct|defexception|defoverridable|alias|case|cond|else|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
+;
+;; ignore module attributes
+;(unary_operator
+;  operator: "@"
+;  operand: (call
+;    target: (identifier) @ignore))
+;
+;; * function call
+;(call
+;  target: [
+;   ; local
+;   (identifier) @name
+;   ; remote
+;   (dot
+;     right: (identifier) @name)
+;  ]) @reference.call
+;
+;; * pipe into function call
+;(binary_operator
+;  operator: "|>"
+;  right: (identifier) @name) @reference.call
+;
+;; * modules
+;(alias) @name @reference.module
+
+(enum_declaration
+  name: (identifier) @name) @definition.enum
+
+(function_signature
+  name: (identifier) @name) @definition.function 
+

--- a/test/tags/flutter.dart
+++ b/test/tags/flutter.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  //  ^ @definition.class
+  const MyApp({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+Future<void> hello() async {
+  //          ^ @definition.function
+}
+
+Stream<String> helloStream() async* {
+  //                  ^ @definition.function
+}
+Iterable<String> helloIter() sync* {
+  //              ^ @definition.function
+}

--- a/test/tags/functions.dart
+++ b/test/tags/functions.dart
@@ -1,0 +1,34 @@
+class SomeClass {
+  //  ^ @definition.class
+  final str = '';
+  int get getter => 12;
+  //       ^ @definition.method
+  void set setter(int value) {}
+  //        ^ @definition.method
+  void method() => print('asdf');
+  //    ^ @definition.method
+}
+
+String topLevelFn() => 'str';
+//      ^ @definition.function
+
+extension SomeExtension on SomeClass {
+  //       ^ @definition.extension
+  void extensionMethod() => print('extension');
+  //    ^ @definition.method
+}
+
+void main() {
+  final instance = SomeClass();
+  instance.str;
+  instance.getter;
+  instance.setter = 12;
+  instance.method();
+  topLevelFn();
+  instance.extensionMethod();
+  instance
+    ..method()
+    ..str
+    ..getter;
+}
+

--- a/test/tags/functions.dart
+++ b/test/tags/functions.dart
@@ -19,16 +19,36 @@ extension SomeExtension on SomeClass {
 }
 
 void main() {
-  final instance = SomeClass();
+  final instance = SomeClass(1, 2, 3).method();
+  //               ^ @reference.class
+  //                                    ^ @reference.call
+  SomeClass().getter;
   instance.str;
   instance.getter;
+  //        ^ @reference.call
+  instance?.getter;
+  //        ^ @reference.call
   instance.setter = 12;
+  //        ^ @reference.call
+  instance?.setter = 12;
+  //        ^ @reference.call
   instance.method();
-  topLevelFn();
+  //        ^ @reference.call
+  instance?.method()!.length();
+  //        ^ @reference.call
+  topLevelFn(1, 2)!.length?.toString();
+  //                             ^ @reference.call
+  topLevelFn;
+  //      ^ @reference.call
   instance.extensionMethod();
+  instance!.extensionMethod();
+  //          ^ @reference.call
   instance
     ..method()
+    // ^ @reference.call
     ..str
+    // ^ @reference.call
     ..getter;
+  //   ^ @reference.call
 }
 

--- a/test/tags/keywords.dart
+++ b/test/tags/keywords.dart
@@ -1,0 +1,139 @@
+library keyword.test;
+
+import 'foo.dart' as test show A hide B;
+
+export 'other.dart';
+
+part 'other2.dart';
+
+enum Bar { a, b }
+//   ^ @definition.enum
+
+typedef Test = Function();
+//      ^ @definition.type
+
+abstract class Foo extends Other3 implements Other2 {
+  //            ^ @definition.class
+  int _bar = 1;
+  //
+  int get bar => _bar;
+  //       ^ @definition.method
+  set bar(int value) => _bar = value;
+  //   ^ @definition.method
+
+  operator [](int index) => null;
+}
+
+class Other extends Foo {
+  //   ^ @definition.class
+  static int a = 1;
+  final int b = 2;
+
+  void foo(covariant String test) {}
+  //    ^ @definition.method
+  factory Other.something() => Other();
+  //       ^ @definition.method
+
+  Other() : super() {
+    this.b;
+  }
+}
+
+class Other2 {}
+//    ^ @definition.class
+
+class Other3 with Other4 {}
+//     ^ @definition.class
+
+mixin Other4 {}
+//     ^ @definition.mixin
+
+void main() {
+  assert(1 == 1);
+  const foo = 1;
+  final bar = 2;
+  var car = null;
+
+  new Other();
+
+  for (var i = 0; i < 10; i++) {
+    continue;
+  }
+
+  for (var i in [1, 2, 3]) {}
+
+  switch (true) {
+    case true:
+      break;
+    default:
+      break;
+  }
+
+  if (1 is int) {
+  } else {}
+
+  do {
+    print('asdf');
+  } while (1 == 2);
+
+  try {
+    throw Exception();
+  } on Exception {
+  } catch (e) {
+    rethrow;
+  } finally {}
+}
+
+void foo() async {
+  // ^ @definition.function
+  await other('');
+}
+
+Future<void> other(dynamic test) async {
+  //          ^ @definition.function
+  return;
+}
+
+extension Something on int {}
+//             ^ @definition.extension
+
+Iterable<int> bar() sync* {
+  //           ^ @definition.function
+  yield 1;
+}
+
+Stream<int> bar2() async* {
+  //         ^ @definition.function
+  yield 1;
+}
+
+// the following are keywords, that can also be used as identifiers
+// verify that each is highlighted as an identifier
+void identifierTest() {
+  // ^ @definition.function
+  var abstract = 1;
+  var as = 1;
+  var async = 1;
+  var covariant = 1;
+  var deferred = 1;
+  var export = 1;
+  var extension = 1;
+  var external = 1;
+  var factory = 1;
+  var get = 1;
+  var hide = 1;
+  var implements = 1;
+  var import = 1;
+  var interface = 1;
+  var library = 1;
+  var mixin = 1;
+  var on = 1;
+  var operator = 1;
+  var part = 1;
+  var set = 1;
+  var show = 1;
+  var static = 1;
+  var sync = 1;
+  var typedef = 1;
+}
+

--- a/test/tags/types.dart
+++ b/test/tags/types.dart
@@ -1,0 +1,58 @@
+enum Material {
+  //  ^ @definition.enum
+  DENIM,
+  CANVAS
+}
+
+class Person {
+  //    ^ @definition.class
+  String name;
+
+  Person(String name) {
+    this.name = name;
+    this.pants = new Pants<Pocket>();
+  }
+
+  Person.other(this.name);
+
+  String getName() {
+    //   ^ @definition.method
+    return this.name;
+  }
+}
+
+class Collections {
+  //    ^ @definition.class
+  static List<T> emptyList<T>() {
+    //             ^ @definition.method
+    return [];
+  }
+}
+
+class someClass<T> {
+  //    ^ @definition.class
+  List<T> someMethod() {
+    //     ^ @definition.method
+    List<T> list = Collections.emptyList<T>();
+    return list;
+  }
+
+  void anotherMethod<S>(S arg) {
+    //   ^ @definition.method
+    List<S> list = Collections.emptyList<S>();
+  }
+}
+
+class TestClass<A, B> {
+// 		 ^ @definition.class
+
+  List<String> foo() {
+    //          ^ @definition.method
+    return <String>[];
+  }
+
+  Map test<A, B>() {
+    //  ^ @definition.method
+    return Map<int, String>.from(<int, String>{});
+  }
+}


### PR DESCRIPTION
closes: #63 


Tag query is important for support tree-sitter based CLI tools like below:

* [aider.chat](https://aider.chat/) : Open source copilot chat alternative, which generates repo-map based on treesitter tag query for precise recommendation
* [CLine ex)Claude dev](https://github.com/cline/cline)

As I mentioned above example, We can utilize tree-sitter's tag query to generating the formalized overview of source code.
I think supporting tag query will have crutial role in dart/flutter development experience