### PR TITLE
Swift - Fix Missing Source File

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
                 ],
                 sources: [
                     "src/parser.c",
-                    // NOTE: if your language has an external scanner, add it here.
+                    "src/scanner.c"
                 ],
                 resources: [
                     .copy("queries")


### PR DESCRIPTION
Fixes a linker error in Swift projects caused by a missing `scanner.c` file in the Swift package manifest.