### PR TITLE
fix: add scanner to python setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_dart/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c",
             ],
             extra_compile_args=[
                 "-std=c11",


### PR DESCRIPTION
As with https://github.com/UserNobody14/tree-sitter-dart/issues/79, building this in python causes an error due to not linking the `scanner.c`. This mirrors another recent fix made here https://github.com/UserNobody14/tree-sitter-dart/pull/78.