### PR TITLE
Generate using ABI 14

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -6,7 +6,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#define LANGUAGE_VERSION 15
+#define LANGUAGE_VERSION 14
 #define STATE_COUNT 3663
 #define LARGE_STATE_COUNT 501
 #define SYMBOL_COUNT 525
@@ -17,7 +17,7 @@
 #define MAX_ALIAS_SEQUENCE_LENGTH 10
 #define MAX_RESERVED_WORD_SET_SIZE 0
 #define PRODUCTION_ID_COUNT 119
-#define SUPERTYPE_COUNT 2
+#define SUPERTYPE_COUNT 0
 
 enum ts_symbol_identifiers {
   sym_identifier = 1,
@@ -7989,48 +7989,6 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [3662] = 3662,
 };
 
-static const TSSymbol ts_supertype_symbols[SUPERTYPE_COUNT] = {
-  sym__literal,
-  sym__statement,
-};
-
-static const TSMapSlice ts_supertype_map_slices[] = {
-  [sym__literal] = {.index = 0, .length = 11},
-  [sym__statement] = {.index = 11, .length = 16},
-};
-
-static const TSSymbol ts_supertype_map_entries[] = {
-  [0] =
-    sym_decimal_floating_point_literal,
-    sym_decimal_integer_literal,
-    sym_false,
-    sym_hex_integer_literal,
-    sym_list_literal,
-    sym_null_literal,
-    sym_record_literal,
-    sym_set_or_map_literal,
-    sym_string_literal,
-    sym_symbol_literal,
-    sym_true,
-  [11] =
-    sym_assert_statement,
-    sym_block,
-    sym_break_statement,
-    sym_continue_statement,
-    sym_do_statement,
-    sym_expression_statement,
-    sym_for_statement,
-    sym_if_statement,
-    sym_local_function_declaration,
-    sym_local_variable_declaration,
-    sym_return_statement,
-    sym_switch_statement,
-    sym_try_statement,
-    sym_while_statement,
-    sym_yield_each_statement,
-    sym_yield_statement,
-};
-
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
   eof = lexer->eof(lexer);
@@ -11163,7 +11121,7 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   }
 }
 
-static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
   [1] = {.lex_state = 99, .external_lex_state = 2},
   [2] = {.lex_state = 100, .external_lex_state = 2},
@@ -201949,7 +201907,6 @@ TS_PUBLIC const TSLanguage *tree_sitter_dart(void) {
     .state_count = STATE_COUNT,
     .large_state_count = LARGE_STATE_COUNT,
     .production_id_count = PRODUCTION_ID_COUNT,
-    .supertype_count = SUPERTYPE_COUNT,
     .field_count = FIELD_COUNT,
     .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
     .parse_table = &ts_parse_table[0][0],
@@ -201960,9 +201917,6 @@ TS_PUBLIC const TSLanguage *tree_sitter_dart(void) {
     .field_names = ts_field_names,
     .field_map_slices = ts_field_map_slices,
     .field_map_entries = ts_field_map_entries,
-    .supertype_map_slices = ts_supertype_map_slices,
-    .supertype_map_entries = ts_supertype_map_entries,
-    .supertype_symbols = ts_supertype_symbols,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,
@@ -201981,13 +201935,6 @@ TS_PUBLIC const TSLanguage *tree_sitter_dart(void) {
       tree_sitter_dart_external_scanner_deserialize,
     },
     .primary_state_ids = ts_primary_state_ids,
-    .name = "dart",
-    .max_reserved_word_set_size = 0,
-    .metadata = {
-      .major_version = 1,
-      .minor_version = 0,
-      .patch_version = 0,
-    },
   };
   return &language;
 }


### PR DESCRIPTION
# What this PR does

Commits the diff resulting from running
```sh
git checkout 0fc19c3a57b1109802af41d2b8f60d8835c5da3a && npx tree-sitter generate --abi 14
```

# Motivation
As of version 0.8.3, `datadog-static-analyzer` uses [tree-sitter 0.24.7](https://github.com/DataDog/datadog-static-analyzer/blob/245657490b70e9eb13a984db9caef9ea88f19261/Cargo.toml#L44), which only supports up to ABI 14. Upstream builds with ABI 15.