### PR TITLE
Add syntax highlighting for modern Dart 3+ features

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -245,3 +245,35 @@
 (annotation
   "@" @attribute
   name: (identifier) @attribute)
+
+; Modern Dart 3+ Features
+; --------------------
+
+; Extension Types
+(extension_type_declaration
+  "type" @keyword)
+
+(extension_type_declaration
+  name: (identifier) @type)
+
+(representation_declaration
+  name: (identifier) @property)
+
+; Switch Guards ("when")
+(switch_expression_case
+  "when" @keyword)
+
+(switch_statement_case
+  "when" @keyword)
+
+; Patterns & Pattern Matching
+(object_pattern
+  (identifier) @property)
+
+(record_pattern
+  (identifier) @property)
+
+; Record Types
+(record_type_field
+  (identifier) @variable)
+

--- a/test/highlight/modern.dart
+++ b/test/highlight/modern.dart
@@ -9,8 +9,8 @@ void testSwitch(Object x) {
   switch (x) {
     case Point(x: var px) when px > 0:
       //   ^ type
-      //         ^ property
-      //                ^ variable
+      //       ^ property
+      //              ^ variable
       //                    ^ keyword
       break;
   }

--- a/test/highlight/modern.dart
+++ b/test/highlight/modern.dart
@@ -1,0 +1,23 @@
+extension type MyId(int id) {}
+// <- keyword
+//        ^ keyword
+//             ^ type
+//                  ^ type.builtin
+//                      ^ property
+
+void testSwitch(Object x) {
+  switch (x) {
+    case Point(x: var px) when px > 0:
+      //   ^ type
+      //         ^ property
+      //                ^ variable
+      //                    ^ keyword
+      break;
+  }
+}
+
+typedef RecordType = (int val, String name);
+//                    ^ type.builtin
+//                        ^ variable
+//                             ^ type.builtin
+//                                    ^ variable


### PR DESCRIPTION
Adds syntax highlighting queries to `queries/highlights.scm` to fully support modern Dart 3+ AST nodes produced by the parser.

Specifically, this adds highlighting for:
- **Extension Types**: Highlights the `type` keyword in `extension type` declarations and the underlying type/identifier in the `representation_declaration`.
- **Switch Guards**: Captures the `when` keyword inside `switch_expression_case` and `switch_statement_case` via the flattened `_guarded_pattern`.
- **Patterns & Matching**: Correctly highlights property names in `object_pattern` and `record_pattern` destructurings.
- **Record Types**: Highlights the named parameters (variables) defined inside a `record_type_field`.

Also introduces `test/highlight/modern.dart` to verify the new queries, ensuring no regressions. All 13 assertions in the new test file pass successfully.
